### PR TITLE
feat(mcp): expose sub-results and add configurable maxSubResults

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -29,14 +29,39 @@ export function createServer(engine: SearchEngine): McpServer {
     "search",
     {
       description:
-        "Semantic site search powered by Upstash Search. Returns url/title/snippet/chunkText/score/routeFile for each match. chunkText contains the full raw chunk markdown. Supports optional scope, pathPrefix, tags, topK, and groupBy.",
+        "Semantic site search powered by Upstash Search. Returns url, title, snippet, chunkText, score, and routeFile per result. chunkText contains the full raw chunk markdown. When groupBy is 'page' (default), each result includes a chunks array with section-level sub-results containing sectionTitle, headingPath (breadcrumb trail), snippet, and score. Use chunks[].headingPath to navigate to specific sections.",
       inputSchema: {
         query: z.string().min(1),
         scope: z.string().optional(),
         topK: z.number().int().positive().max(100).optional(),
         pathPrefix: z.string().optional(),
         tags: z.array(z.string()).optional(),
-        groupBy: z.enum(["page", "chunk"]).optional()
+        groupBy: z.enum(["page", "chunk"]).optional(),
+        maxSubResults: z.number().int().positive().max(20).optional()
+      },
+      outputSchema: {
+        q: z.string(),
+        scope: z.string(),
+        results: z.array(z.object({
+          url: z.string(),
+          title: z.string(),
+          sectionTitle: z.string().optional(),
+          snippet: z.string(),
+          score: z.number(),
+          routeFile: z.string(),
+          chunks: z.array(z.object({
+            sectionTitle: z.string().optional(),
+            snippet: z.string(),
+            headingPath: z.array(z.string()),
+            score: z.number()
+          })).optional()
+        })),
+        meta: z.object({
+          timingsMs: z.object({
+            search: z.number(),
+            total: z.number()
+          })
+        })
       }
     },
     async (input) => {
@@ -46,7 +71,8 @@ export function createServer(engine: SearchEngine): McpServer {
         scope: input.scope,
         pathPrefix: input.pathPrefix,
         tags: input.tags,
-        groupBy: input.groupBy
+        groupBy: input.groupBy,
+        maxSubResults: input.maxSubResults
       });
 
       return {
@@ -55,7 +81,8 @@ export function createServer(engine: SearchEngine): McpServer {
             type: "text",
             text: JSON.stringify(result, null, 2)
           }
-        ]
+        ],
+        structuredContent: result as unknown as Record<string, unknown>
       };
     }
   );

--- a/src/search/engine.ts
+++ b/src/search/engine.ts
@@ -29,6 +29,7 @@ const requestSchema = z.object({
   pathPrefix: z.string().optional(),
   tags: z.array(z.string()).optional(),
   groupBy: z.enum(["page", "chunk"]).optional(),
+  maxSubResults: z.number().int().positive().max(20).optional(),
   debug: z.boolean().optional()
 });
 
@@ -164,6 +165,7 @@ export class SearchEngine {
     const resolvedScope = resolveScope(this.config, input.scope);
 
     const topK = input.topK ?? 10;
+    const maxSubResults = input.maxSubResults ?? 5;
     const groupByPage = (input.groupBy ?? "page") === "page";
     // Fetch more candidates for page aggregation
     const candidateK = groupByPage
@@ -250,7 +252,7 @@ export class SearchEngine {
     }
     const searchMs = hrTimeMs(searchStart);
 
-    const results = this.buildResults(ranked, topK, groupByPage, input.q, input.debug);
+    const results = this.buildResults(ranked, topK, groupByPage, maxSubResults, input.q, input.debug);
 
     return {
       q: input.q,
@@ -274,7 +276,7 @@ export class SearchEngine {
     return snippet || "";
   }
 
-  private buildResults(ordered: RankedHit[], topK: number, groupByPage: boolean, query?: string, debug?: boolean): SearchResult[] {
+  private buildResults(ordered: RankedHit[], topK: number, groupByPage: boolean, maxSubResults: number, query?: string, debug?: boolean): SearchResult[] {
     if (groupByPage) {
       let pages = aggregateByPage(ordered, this.config);
       pages = trimByScoreGap(pages, this.config);
@@ -284,7 +286,7 @@ export class SearchEngine {
         const minChunkScore = Number.isFinite(bestScore) ? bestScore * minRatio : Number.NEGATIVE_INFINITY;
         const meaningful = page.matchingChunks
           .filter((c) => c.finalScore >= minChunkScore)
-          .slice(0, 5);
+          .slice(0, maxSubResults);
         const result: SearchResult = {
           url: page.url,
           title: page.title,
@@ -293,7 +295,7 @@ export class SearchEngine {
           chunkText: page.bestChunk.hit.metadata.chunkText || undefined,
           score: Number(page.pageScore.toFixed(6)),
           routeFile: page.routeFile,
-          chunks: meaningful.length > 1
+          chunks: meaningful.length >= 1
             ? meaningful.map((c) => ({
                 sectionTitle: c.hit.metadata.sectionTitle || undefined,
                 snippet: this.ensureSnippet(c, query),

--- a/src/svelte/index.svelte.ts
+++ b/src/svelte/index.svelte.ts
@@ -11,6 +11,7 @@ export interface CreateSearchOptions {
   pathPrefix?: string;
   tags?: string[];
   groupBy?: "page" | "chunk";
+  maxSubResults?: number;
 }
 
 class LruCache<K, V> {
@@ -48,6 +49,7 @@ function buildCacheKey(query: string, options: CreateSearchOptions): string {
   if (options.pathPrefix !== undefined) parts.pathPrefix = options.pathPrefix;
   if (options.tags !== undefined) parts.tags = options.tags;
   if (options.groupBy !== undefined) parts.groupBy = options.groupBy;
+  if (options.maxSubResults !== undefined) parts.maxSubResults = options.maxSubResults;
   return JSON.stringify(parts);
 }
 
@@ -106,6 +108,7 @@ export function createSearch(options: CreateSearchOptions = {}): SearchState {
         if (options.pathPrefix !== undefined) request.pathPrefix = options.pathPrefix;
         if (options.tags !== undefined) request.tags = options.tags;
         if (options.groupBy !== undefined) request.groupBy = options.groupBy;
+        if (options.maxSubResults !== undefined) request.maxSubResults = options.maxSubResults;
 
         try {
           const response = await fetchFn(endpoint, {

--- a/src/sveltekit/handle.ts
+++ b/src/sveltekit/handle.ts
@@ -340,6 +340,15 @@ async function handleGetSearch(
     searchRequest.groupBy = groupBy;
   }
 
+  const maxSubResults = params.get("maxSubResults");
+  if (maxSubResults !== null) {
+    const parsed = Number.parseInt(maxSubResults, 10);
+    if (Number.isNaN(parsed) || parsed < 1 || parsed > 20) {
+      throw new SearchSocketError("INVALID_REQUEST", "maxSubResults must be a positive integer between 1 and 20", 400);
+    }
+    searchRequest.maxSubResults = parsed;
+  }
+
   const tags = params.getAll("tags");
   if (tags.length > 0) searchRequest.tags = tags;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -417,6 +417,7 @@ export interface SearchRequest {
   pathPrefix?: string;
   tags?: string[];
   groupBy?: "page" | "chunk";
+  maxSubResults?: number;
   debug?: boolean;
 }
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -271,6 +271,74 @@ describe("get_site_structure tool", () => {
   });
 });
 
+describe("search tool", () => {
+  function getSearchCall(mockEngine: Record<string, unknown>) {
+    const server = createServer(mockEngine as never);
+    const calls = (server.registerTool as ReturnType<typeof vi.fn>).mock.calls;
+    return calls.find((c: unknown[]) => c[0] === "search")!;
+  }
+
+  function getSearchHandler(mockEngine: Record<string, unknown>) {
+    const call = getSearchCall(mockEngine);
+    return call[2] as (input: Record<string, unknown>) => Promise<{
+      content: Array<{ type: string; text: string }>;
+      structuredContent?: Record<string, unknown>;
+    }>;
+  }
+
+  it("description mentions chunks and headingPath", () => {
+    const mockEngine = { search: vi.fn() };
+    const call = getSearchCall(mockEngine);
+    const config = call[1] as { description: string };
+    expect(config.description).toContain("chunks");
+    expect(config.description).toContain("headingPath");
+  });
+
+  it("inputSchema includes maxSubResults", () => {
+    const mockEngine = { search: vi.fn() };
+    const call = getSearchCall(mockEngine);
+    const config = call[1] as { inputSchema: Record<string, unknown> };
+    expect(config.inputSchema).toHaveProperty("maxSubResults");
+  });
+
+  it("outputSchema is defined", () => {
+    const mockEngine = { search: vi.fn() };
+    const call = getSearchCall(mockEngine);
+    const config = call[1] as { outputSchema: unknown };
+    expect(config.outputSchema).toBeDefined();
+  });
+
+  it("forwards maxSubResults to engine.search", async () => {
+    const mockResult = { q: "test", scope: "main", results: [], meta: { timingsMs: { search: 10, total: 15 } } };
+    const mockEngine = { search: vi.fn().mockResolvedValue(mockResult) };
+    const handler = getSearchHandler(mockEngine);
+
+    await handler({ query: "test", maxSubResults: 3 });
+
+    expect(mockEngine.search).toHaveBeenCalledWith(
+      expect.objectContaining({ maxSubResults: 3 })
+    );
+  });
+
+  it("returns both content and structuredContent", async () => {
+    const mockResult = {
+      q: "test",
+      scope: "main",
+      results: [{ url: "/home", title: "Home", snippet: "Welcome", score: 0.9, routeFile: "src/routes/+page.svelte" }],
+      meta: { timingsMs: { search: 10, total: 15 } }
+    };
+    const mockEngine = { search: vi.fn().mockResolvedValue(mockResult) };
+    const handler = getSearchHandler(mockEngine);
+
+    const result = await handler({ query: "test" });
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0]!.type).toBe("text");
+    expect(JSON.parse(result.content[0]!.text)).toEqual(mockResult);
+    expect(result.structuredContent).toEqual(mockResult);
+  });
+});
+
 describe("find_source_file tool", () => {
   function getHandler(mockEngine: Record<string, unknown>) {
     const server = createServer(mockEngine as never);

--- a/tests/search-engine-extended.test.ts
+++ b/tests/search-engine-extended.test.ts
@@ -316,9 +316,10 @@ describe("SearchEngine - adversarial cases", () => {
     expect(homeResult!.chunks).toBeDefined();
     expect(homeResult!.chunks!.length).toBe(3);
 
-    // /about should NOT have sub-chunks since it has only 1 chunk
+    // /about has 1 chunk, which is still included in chunks array
     const aboutResult = result.results.find((r) => r.url === "/about");
-    expect(aboutResult!.chunks).toBeUndefined();
+    expect(aboutResult!.chunks).toBeDefined();
+    expect(aboutResult!.chunks!.length).toBe(1);
   });
 
   it("filters sub-chunks below minChunkScoreRatio", async () => {
@@ -743,6 +744,162 @@ describe("SearchEngine - dual search", () => {
     // /boosted blended: (1-0.3)*0.6 + 0.3*1.0 = 0.42 + 0.3 = 0.72 (plus ranking boosts)
     expect(result.results[0]!.url).toBe("/top");
     expect(result.results[1]!.url).toBe("/boosted");
+  });
+});
+
+describe("SearchEngine - maxSubResults", () => {
+  it("defaults to 5 sub-results when maxSubResults is not specified", async () => {
+    const cwd = await makeTempCwd();
+    const config = createDefaultConfig("searchsocket-engine-test");
+    config.ranking.minChunkScoreRatio = 0;
+
+    // Create 7 chunks for the same page
+    const hits: VectorHit[] = Array.from({ length: 7 }, (_, i) => ({
+      ...makeHit(`chunk-${i}`, "/docs"),
+      score: 0.9 - i * 0.05
+    }));
+
+    const engine = await SearchEngine.create({
+      cwd,
+      config,
+      store: createMockStore(hits),
+      embedder: createMockEmbedder()
+    });
+
+    const result = await engine.search({ q: "test", topK: 10 });
+    const page = result.results[0]!;
+    expect(page.chunks).toBeDefined();
+    expect(page.chunks!.length).toBe(5);
+  });
+
+  it("respects maxSubResults cap", async () => {
+    const cwd = await makeTempCwd();
+    const config = createDefaultConfig("searchsocket-engine-test");
+    config.ranking.minChunkScoreRatio = 0;
+
+    const hits: VectorHit[] = Array.from({ length: 7 }, (_, i) => ({
+      ...makeHit(`chunk-${i}`, "/docs"),
+      score: 0.9 - i * 0.05
+    }));
+
+    const engine = await SearchEngine.create({
+      cwd,
+      config,
+      store: createMockStore(hits),
+      embedder: createMockEmbedder()
+    });
+
+    const result = await engine.search({ q: "test", topK: 10, maxSubResults: 3 });
+    const page = result.results[0]!;
+    expect(page.chunks).toBeDefined();
+    expect(page.chunks!.length).toBe(3);
+  });
+
+  it("returns exactly 1 chunk when maxSubResults is 1", async () => {
+    const cwd = await makeTempCwd();
+    const config = createDefaultConfig("searchsocket-engine-test");
+    config.ranking.minChunkScoreRatio = 0;
+
+    const hits: VectorHit[] = [
+      { ...makeHit("chunk-1", "/page"), score: 0.9 },
+      { ...makeHit("chunk-2", "/page"), score: 0.8 },
+      { ...makeHit("chunk-3", "/page"), score: 0.7 }
+    ];
+
+    const engine = await SearchEngine.create({
+      cwd,
+      config,
+      store: createMockStore(hits),
+      embedder: createMockEmbedder()
+    });
+
+    const result = await engine.search({ q: "test", topK: 10, maxSubResults: 1 });
+    const page = result.results[0]!;
+    expect(page.chunks).toBeDefined();
+    expect(page.chunks!.length).toBe(1);
+  });
+
+  it("returns all available chunks when maxSubResults exceeds actual count", async () => {
+    const cwd = await makeTempCwd();
+    const config = createDefaultConfig("searchsocket-engine-test");
+    config.ranking.minChunkScoreRatio = 0;
+
+    const hits: VectorHit[] = [
+      { ...makeHit("chunk-1", "/page"), score: 0.9 },
+      { ...makeHit("chunk-2", "/page"), score: 0.8 }
+    ];
+
+    const engine = await SearchEngine.create({
+      cwd,
+      config,
+      store: createMockStore(hits),
+      embedder: createMockEmbedder()
+    });
+
+    const result = await engine.search({ q: "test", topK: 10, maxSubResults: 10 });
+    const page = result.results[0]!;
+    expect(page.chunks).toBeDefined();
+    expect(page.chunks!.length).toBe(2);
+  });
+
+  it("rejects maxSubResults of 0", async () => {
+    const cwd = await makeTempCwd();
+    const config = createDefaultConfig("searchsocket-engine-test");
+
+    const engine = await SearchEngine.create({
+      cwd,
+      config,
+      store: createMockStore(),
+      embedder: createMockEmbedder()
+    });
+
+    await expect(engine.search({ q: "test", maxSubResults: 0 })).rejects.toMatchObject({
+      code: "INVALID_REQUEST",
+      status: 400
+    });
+  });
+
+  it("rejects maxSubResults exceeding 20", async () => {
+    const cwd = await makeTempCwd();
+    const config = createDefaultConfig("searchsocket-engine-test");
+
+    const engine = await SearchEngine.create({
+      cwd,
+      config,
+      store: createMockStore(),
+      embedder: createMockEmbedder()
+    });
+
+    await expect(engine.search({ q: "test", maxSubResults: 21 })).rejects.toMatchObject({
+      code: "INVALID_REQUEST",
+      status: 400
+    });
+  });
+
+  it("has no effect on chunk-mode results", async () => {
+    const cwd = await makeTempCwd();
+    const config = createDefaultConfig("searchsocket-engine-test");
+    config.ranking.minScore = 0;
+    config.ranking.scoreGapThreshold = 0;
+
+    const hits: VectorHit[] = [
+      { ...makeHit("chunk-1", "/home"), score: 0.9 },
+      { ...makeHit("chunk-2", "/home"), score: 0.7 },
+      { ...makeHit("chunk-3", "/about"), score: 0.85 }
+    ];
+
+    const engine = await SearchEngine.create({
+      cwd,
+      config,
+      store: createMockStore(hits),
+      embedder: createMockEmbedder()
+    });
+
+    const result = await engine.search({ q: "test", topK: 10, groupBy: "chunk", maxSubResults: 1 });
+    expect(result.results.length).toBe(3);
+    for (const r of result.results) {
+      expect(r.chunks).toBeUndefined();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `maxSubResults` to `SearchRequest`, letting callers control how many chunks come back per page result (defaults to 5, was previously hardcoded)
- Updates the MCP `search` tool with an `outputSchema` and `structuredContent` so AI agents get typed, machine-readable results rather than a plain text blob
- Improves the tool description to document the `chunks` response field, including `sectionTitle`, `headingPath`, `snippet`, and `score`, so agents actually know section-level results exist
- Changes chunk inclusion threshold from `> 1` to `>= 1` so single-chunk pages still return sub-results

Resolves #49

## Changes

- `src/types.ts`: added `maxSubResults?: number` to `SearchRequest`
- `src/search/engine.ts`: threads `maxSubResults` through to `buildResultUrl` / chunk limiting logic
- `src/mcp/server.ts`: adds Zod `outputSchema`, returns `structuredContent` alongside text, extends tool description with chunks documentation, exposes `maxSubResults` input parameter
- `src/sveltekit/handle.ts`: forwards `maxSubResults` from GET query params
- `src/svelte/index.svelte.ts`: forwards `maxSubResults` from client search options
- Tests in `tests/mcp-server.test.ts` and `tests/search-engine-extended.test.ts` covering the new parameter and MCP output shape

## Testing

Full test suite passes (`pnpm run test`). Typecheck passes clean. New tests cover `maxSubResults` clamping, default behaviour, the MCP `structuredContent` output, and the `>= 1` chunk inclusion change.