### PR TITLE
feat(search): query-aware excerpts and expose chunkText in results

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -29,7 +29,7 @@ export function createServer(engine: SearchEngine): McpServer {
     "search",
     {
       description:
-        "Semantic site search powered by Upstash Search. Returns url/title/snippet/score/routeFile for each match. Supports optional scope, pathPrefix, tags, topK, and groupBy.",
+        "Semantic site search powered by Upstash Search. Returns url/title/snippet/chunkText/score/routeFile for each match. chunkText contains the full raw chunk markdown. Supports optional scope, pathPrefix, tags, topK, and groupBy.",
       inputSchema: {
         query: z.string().min(1),
         scope: z.string().optional(),

--- a/src/search/engine.ts
+++ b/src/search/engine.ts
@@ -20,7 +20,7 @@ import type {
 } from "../types";
 import type { UpstashSearchStore } from "../vector/upstash";
 import type { RankedHit, PageResult } from "./ranking";
-import { toSnippet } from "../utils/text";
+import { toSnippet, queryAwareExcerpt } from "../utils/text";
 
 const requestSchema = z.object({
   q: z.string().trim().min(1),
@@ -265,15 +265,16 @@ export class SearchEngine {
     };
   }
 
-  private ensureSnippet(hit: RankedHit): string {
+  private ensureSnippet(hit: RankedHit, query?: string): string {
+    const chunkText = hit.hit.metadata.chunkText;
+    if (query && chunkText) return queryAwareExcerpt(chunkText, query);
     const snippet = hit.hit.metadata.snippet;
     if (snippet && snippet.length >= 30) return snippet;
-    const chunkText = hit.hit.metadata.chunkText;
     if (chunkText) return toSnippet(chunkText);
     return snippet || "";
   }
 
-  private buildResults(ordered: RankedHit[], topK: number, groupByPage: boolean, _query?: string, debug?: boolean): SearchResult[] {
+  private buildResults(ordered: RankedHit[], topK: number, groupByPage: boolean, query?: string, debug?: boolean): SearchResult[] {
     if (groupByPage) {
       let pages = aggregateByPage(ordered, this.config);
       pages = trimByScoreGap(pages, this.config);
@@ -288,13 +289,15 @@ export class SearchEngine {
           url: page.url,
           title: page.title,
           sectionTitle: page.bestChunk.hit.metadata.sectionTitle || undefined,
-          snippet: this.ensureSnippet(page.bestChunk),
+          snippet: this.ensureSnippet(page.bestChunk, query),
+          chunkText: page.bestChunk.hit.metadata.chunkText || undefined,
           score: Number(page.pageScore.toFixed(6)),
           routeFile: page.routeFile,
           chunks: meaningful.length > 1
             ? meaningful.map((c) => ({
                 sectionTitle: c.hit.metadata.sectionTitle || undefined,
-                snippet: this.ensureSnippet(c),
+                snippet: this.ensureSnippet(c, query),
+                chunkText: c.hit.metadata.chunkText || undefined,
                 headingPath: c.hit.metadata.headingPath,
                 score: Number(c.finalScore.toFixed(6))
               }))
@@ -316,7 +319,8 @@ export class SearchEngine {
           url: hit.metadata.url,
           title: hit.metadata.title,
           sectionTitle: hit.metadata.sectionTitle || undefined,
-          snippet: this.ensureSnippet({ hit, finalScore }),
+          snippet: this.ensureSnippet({ hit, finalScore }, query),
+          chunkText: hit.metadata.chunkText || undefined,
           score: Number(finalScore.toFixed(6)),
           routeFile: hit.metadata.routeFile
         };

--- a/src/types.ts
+++ b/src/types.ts
@@ -430,6 +430,7 @@ export interface ScoreBreakdown {
 export interface SearchResultChunk {
   sectionTitle?: string;
   snippet: string;
+  chunkText?: string;
   headingPath: string[];
   score: number;
 }
@@ -439,6 +440,7 @@ export interface SearchResult {
   title: string;
   sectionTitle?: string;
   snippet: string;
+  chunkText?: string;
   score: number;
   routeFile: string;
   chunks?: SearchResultChunk[];

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -14,19 +14,117 @@ export function sanitizeScopeName(scopeName: string): string {
     .slice(0, 80);
 }
 
-export function toSnippet(markdown: string, maxLen = 220): string {
-  const plain = markdown
+function markdownToPlain(markdown: string): string {
+  return markdown
     .replace(/```[\s\S]*?```/g, " ")
     .replace(/`([^`]+)`/g, "$1")
     .replace(/[#>*_|\-]/g, " ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+export function toSnippet(markdown: string, maxLen = 220): string {
+  const plain = markdownToPlain(markdown);
 
   if (plain.length <= maxLen) {
     return plain;
   }
 
   return `${plain.slice(0, Math.max(0, maxLen - 1)).trim()}…`;
+}
+
+export function queryAwareExcerpt(markdown: string, query: string, maxLen = 220): string {
+  const plain = markdownToPlain(markdown);
+  if (plain.length <= maxLen) return plain;
+
+  const tokens = query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t.length >= 2);
+
+  if (tokens.length === 0) return toSnippet(markdown, maxLen);
+
+  // Find all match positions in the plain text, tagged by token index
+  const positions: Array<{ start: number; end: number; tokenIdx: number }> = [];
+  for (let ti = 0; ti < tokens.length; ti++) {
+    const escaped = tokens[ti]!.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const re = new RegExp(escaped, "gi");
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(plain)) !== null) {
+      positions.push({ start: m.index, end: m.index + m[0].length, tokenIdx: ti });
+    }
+  }
+
+  if (positions.length === 0) return toSnippet(markdown, maxLen);
+
+  positions.sort((a, b) => a.start - b.start);
+
+  // Two-pointer sliding window: find the window with most unique terms fitting in maxLen chars
+  // Tie-break by total match count
+  let bestUniqueCount = 0;
+  let bestTotalCount = 0;
+  let bestLeft = 0;
+  let bestRight = 0;
+  let left = 0;
+  const tokenCounts = new Map<number, number>();
+
+  for (let right = 0; right < positions.length; right++) {
+    tokenCounts.set(positions[right]!.tokenIdx, (tokenCounts.get(positions[right]!.tokenIdx) ?? 0) + 1);
+
+    // Shrink from left while the window span exceeds maxLen
+    while (positions[right]!.end - positions[left]!.start > maxLen && left < right) {
+      const leftToken = positions[left]!.tokenIdx;
+      const cnt = tokenCounts.get(leftToken)! - 1;
+      if (cnt === 0) tokenCounts.delete(leftToken);
+      else tokenCounts.set(leftToken, cnt);
+      left++;
+    }
+
+    const uniqueCount = tokenCounts.size;
+    const totalCount = right - left + 1;
+    if (uniqueCount > bestUniqueCount || (uniqueCount === bestUniqueCount && totalCount > bestTotalCount)) {
+      bestUniqueCount = uniqueCount;
+      bestTotalCount = totalCount;
+      bestLeft = left;
+      bestRight = right;
+    }
+  }
+
+  // Center the excerpt around the midpoint of the best window
+  const mid = Math.floor((positions[bestLeft]!.start + positions[bestRight]!.end) / 2);
+  let start = Math.max(0, mid - Math.floor(maxLen / 2));
+  let end = Math.min(plain.length, start + maxLen);
+  // Re-adjust start if end hit the boundary
+  start = Math.max(0, end - maxLen);
+
+  // Snap to word boundaries
+  if (start > 0) {
+    const spaceIdx = plain.lastIndexOf(" ", start);
+    if (spaceIdx > start - 30) {
+      start = spaceIdx + 1;
+    }
+  }
+  if (end < plain.length) {
+    const spaceIdx = plain.indexOf(" ", end);
+    if (spaceIdx !== -1 && spaceIdx < end + 30) {
+      end = spaceIdx;
+    }
+  }
+
+  let excerpt = plain.slice(start, end);
+
+  // Hard-trim if word-boundary snapping expanded beyond limit
+  if (excerpt.length > Math.ceil(maxLen * 1.2)) {
+    excerpt = excerpt.slice(0, maxLen);
+    const lastSpace = excerpt.lastIndexOf(" ");
+    if (lastSpace > maxLen * 0.5) {
+      excerpt = excerpt.slice(0, lastSpace);
+    }
+  }
+
+  const prefix = start > 0 ? "…" : "";
+  const suffix = end < plain.length ? "…" : "";
+  return `${prefix}${excerpt}${suffix}`;
 }
 
 export function extractFirstParagraph(markdown: string): string {

--- a/tests/search-engine-extended.test.ts
+++ b/tests/search-engine-extended.test.ts
@@ -432,13 +432,13 @@ describe("SearchEngine - adversarial cases", () => {
     expect(result.results[0]!.snippet).toContain("Terminal Features");
   });
 
-  it("keeps original snippet when it is long enough", async () => {
+  it("generates query-aware snippet from chunkText when query is present", async () => {
     const cwd = await makeTempCwd();
     const config = createDefaultConfig("searchsocket-engine-test");
     config.ranking.minScore = 0;
     config.ranking.scoreGapThreshold = 0;
 
-    const longSnippet = "This is a sufficiently long snippet that should not be replaced by chunk text fallback.";
+    const longSnippet = "This is the original stored snippet that was computed at index time without query context.";
     const hits: VectorHit[] = [
       {
         ...makeHit("chunk-long", "/docs"),
@@ -446,7 +446,7 @@ describe("SearchEngine - adversarial cases", () => {
         metadata: {
           ...makeHit("chunk-long", "/docs").metadata,
           snippet: longSnippet,
-          chunkText: "Different chunk text content."
+          chunkText: "Different chunk text content about docs and documentation features."
         }
       }
     ];
@@ -459,7 +459,9 @@ describe("SearchEngine - adversarial cases", () => {
     });
 
     const result = await engine.search({ q: "docs", topK: 10 });
-    expect(result.results[0]!.snippet).toBe(longSnippet);
+    // Query-aware excerpt regenerates from chunkText, so it won't match the stored snippet
+    expect(result.results[0]!.snippet).not.toBe(longSnippet);
+    expect(result.results[0]!.snippet).toContain("docs");
   });
 
   it("trims low-confidence results via score-gap trimming", async () => {
@@ -484,6 +486,108 @@ describe("SearchEngine - adversarial cases", () => {
     // The weak result should be trimmed due to score gap
     expect(result.results.length).toBe(2);
     expect(result.results.map((r) => r.url)).toEqual(["/relevant", "/also-relevant"]);
+  });
+
+  it("populates chunkText on top-level result when metadata.chunkText is present", async () => {
+    const cwd = await makeTempCwd();
+    const config = createDefaultConfig("searchsocket-engine-test");
+    config.ranking.minScore = 0;
+    config.ranking.scoreGapThreshold = 0;
+
+    const hits: VectorHit[] = [
+      {
+        ...makeHit("chunk-1", "/page"),
+        score: 0.9,
+        metadata: {
+          ...makeHit("chunk-1", "/page").metadata,
+          chunkText: "Full markdown content of the chunk."
+        }
+      }
+    ];
+
+    const engine = await SearchEngine.create({
+      cwd,
+      config,
+      store: createMockStore(hits),
+      embedder: createMockEmbedder()
+    });
+
+    const result = await engine.search({ q: "test", topK: 10 });
+    expect(result.results[0]!.chunkText).toBe("Full markdown content of the chunk.");
+  });
+
+  it("chunkText is undefined when metadata.chunkText is empty", async () => {
+    const cwd = await makeTempCwd();
+    const config = createDefaultConfig("searchsocket-engine-test");
+    config.ranking.minScore = 0;
+    config.ranking.scoreGapThreshold = 0;
+
+    const hits: VectorHit[] = [
+      {
+        ...makeHit("chunk-1", "/page"),
+        score: 0.9,
+        metadata: {
+          ...makeHit("chunk-1", "/page").metadata,
+          chunkText: ""
+        }
+      }
+    ];
+
+    const engine = await SearchEngine.create({
+      cwd,
+      config,
+      store: createMockStore(hits),
+      embedder: createMockEmbedder()
+    });
+
+    const result = await engine.search({ q: "test", topK: 10 });
+    expect(result.results[0]!.chunkText).toBeUndefined();
+  });
+
+  it("populates chunkText on nested chunk entries", async () => {
+    const cwd = await makeTempCwd();
+    const config = createDefaultConfig("searchsocket-engine-test");
+    config.ranking.minScore = 0;
+    config.ranking.scoreGapThreshold = 0;
+
+    const hits: VectorHit[] = [
+      { ...makeHit("chunk-1", "/page"), score: 0.9, metadata: { ...makeHit("chunk-1", "/page").metadata, chunkText: "Chunk one content." } },
+      { ...makeHit("chunk-2", "/page"), score: 0.85, metadata: { ...makeHit("chunk-2", "/page").metadata, chunkText: "Chunk two content." } }
+    ];
+
+    const engine = await SearchEngine.create({
+      cwd,
+      config,
+      store: createMockStore(hits),
+      embedder: createMockEmbedder()
+    });
+
+    const result = await engine.search({ q: "test", topK: 10 });
+    const pageResult = result.results[0]!;
+    expect(pageResult.chunks).toBeDefined();
+    expect(pageResult.chunks![0]!.chunkText).toBe("Chunk one content.");
+    expect(pageResult.chunks![1]!.chunkText).toBe("Chunk two content.");
+  });
+
+  it("populates chunkText in chunk-mode results", async () => {
+    const cwd = await makeTempCwd();
+    const config = createDefaultConfig("searchsocket-engine-test");
+    config.ranking.minScore = 0;
+    config.ranking.scoreGapThreshold = 0;
+
+    const hits: VectorHit[] = [
+      { ...makeHit("chunk-1", "/page"), score: 0.9, metadata: { ...makeHit("chunk-1", "/page").metadata, chunkText: "Chunk markdown here." } }
+    ];
+
+    const engine = await SearchEngine.create({
+      cwd,
+      config,
+      store: createMockStore(hits),
+      embedder: createMockEmbedder()
+    });
+
+    const result = await engine.search({ q: "test", topK: 10, groupBy: "chunk" });
+    expect(result.results[0]!.chunkText).toBe("Chunk markdown here.");
   });
 
   it("returns empty results for gibberish queries with low scores", async () => {

--- a/tests/text-utils.test.ts
+++ b/tests/text-utils.test.ts
@@ -5,7 +5,8 @@ import {
   sanitizeScopeName,
   toSnippet,
   safeJsonParse,
-  extractFirstParagraph
+  extractFirstParagraph,
+  queryAwareExcerpt
 } from "../src/utils/text";
 
 describe("normalizeText", () => {
@@ -98,6 +99,111 @@ describe("extractFirstParagraph", () => {
   it("extracts paragraph when no heading precedes it", () => {
     const md = "Just a plain paragraph.\n\nAnother one.";
     expect(extractFirstParagraph(md)).toBe("Just a plain paragraph.");
+  });
+});
+
+describe("queryAwareExcerpt", () => {
+  it("centers excerpt on keyword cluster in the middle of text", () => {
+    const prefix = "Lorem ipsum dolor sit amet. ".repeat(10); // ~280 chars
+    const target = "The authentication middleware handles user sessions securely.";
+    const suffix = " Consectetur adipiscing elit. ".repeat(10);
+    const markdown = prefix + target + suffix;
+
+    const result = queryAwareExcerpt(markdown, "authentication middleware");
+    expect(result).toContain("authentication middleware");
+    expect(result.startsWith("…")).toBe(true);
+    expect(result.endsWith("…")).toBe(true);
+  });
+
+  it("returns full text without ellipsis when text is shorter than maxLen", () => {
+    const short = "A short piece of text about authentication.";
+    const result = queryAwareExcerpt(short, "authentication");
+    expect(result).toBe("A short piece of text about authentication.");
+    expect(result).not.toContain("…");
+  });
+
+  it("falls back to toSnippet when no query terms match", () => {
+    const text = "The quick brown fox jumps over the lazy dog. ".repeat(10);
+    const result = queryAwareExcerpt(text, "xylophone quantum");
+    const fallback = toSnippet(text);
+    expect(result).toBe(fallback);
+  });
+
+  it("falls back to toSnippet for empty query", () => {
+    const text = "Some long text content. ".repeat(20);
+    const result = queryAwareExcerpt(text, "");
+    const fallback = toSnippet(text);
+    expect(result).toBe(fallback);
+  });
+
+  it("filters out single-character query tokens", () => {
+    const prefix = "Other content here. ".repeat(10);
+    const text = prefix + "The big red balloon floated away." + " More content. ".repeat(10);
+    const result = queryAwareExcerpt(text, "a balloon");
+    // "a" is filtered out (length < 2), only "balloon" is used
+    expect(result).toContain("balloon");
+  });
+
+  it("handles regex metacharacters in query terms", () => {
+    const text = "We support C++ and Java programming. ".repeat(8);
+    expect(() => queryAwareExcerpt(text, "c++")).not.toThrow();
+    const result = queryAwareExcerpt(text, "c++");
+    expect(result).toContain("C++");
+  });
+
+  it("handles query with parentheses", () => {
+    const text = "The auth(middleware) function validates tokens. ".repeat(8);
+    expect(() => queryAwareExcerpt(text, "auth(middleware)")).not.toThrow();
+    const result = queryAwareExcerpt(text, "auth(middleware)");
+    expect(result).toContain("auth(middleware)");
+  });
+
+  it("prefers regions with multiple distinct terms over single repeated term", () => {
+    // Place "deploy" far from "kubernetes", then have them close together later
+    const parts = [
+      "deploy ".repeat(20),                          // many deploys at start
+      "filler content here. ".repeat(10),
+      "kubernetes deploy cluster orchestration. ",    // both terms together
+      "more filler. ".repeat(10)
+    ];
+    const text = parts.join("");
+    const result = queryAwareExcerpt(text, "kubernetes deploy", 100);
+    expect(result).toContain("kubernetes");
+    expect(result).toContain("deploy");
+  });
+
+  it("no leading ellipsis when excerpt starts at beginning", () => {
+    const text = "authentication is the first word here. " + "padding content. ".repeat(20);
+    const result = queryAwareExcerpt(text, "authentication");
+    expect(result.startsWith("…")).toBe(false);
+    expect(result).toContain("authentication");
+  });
+
+  it("no trailing ellipsis when excerpt reaches end of text", () => {
+    const text = "padding content. ".repeat(20) + "this is the final authentication check.";
+    const result = queryAwareExcerpt(text, "authentication");
+    expect(result.endsWith("…")).toBe(false);
+    expect(result).toContain("authentication");
+  });
+
+  it("strips markdown before scanning for keywords", () => {
+    const md = "# Heading\n\n```js\nconst x = 1;\n```\n\nThe **important** keyword is here. " + "filler. ".repeat(30);
+    const result = queryAwareExcerpt(md, "important keyword");
+    expect(result).toContain("important");
+    expect(result).toContain("keyword");
+    expect(result).not.toContain("```");
+    expect(result).not.toContain("**");
+  });
+
+  it("returns empty string for empty markdown", () => {
+    expect(queryAwareExcerpt("", "test")).toBe("");
+  });
+
+  it("respects custom maxLen parameter", () => {
+    const text = "word ".repeat(100);
+    const result = queryAwareExcerpt(text, "word", 50);
+    // Allow some tolerance for word-boundary snapping and ellipsis
+    expect(result.length).toBeLessThanOrEqual(70);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `queryAwareExcerpt()` in `src/utils/text.ts` using a keyword density sliding window to find the region of a chunk with the most query term matches, rather than always taking the first 220 characters
- Exposes `chunkText` on both `SearchResult` and `SearchResultChunk` so MCP consumers and search clients get the raw markdown content alongside the snippet
- Wires the query string through `ensureSnippet()` and `buildResults()` in the search engine so the excerpt logic has what it needs at result-build time

Resolves #50

## Changes

- `src/utils/text.ts`: new `queryAwareExcerpt()` function with configurable window size and fallback to the existing `toSnippet()` behaviour when there's no keyword overlap
- `src/search/engine.ts`: passes query through `ensureSnippet` and `buildResults`, populates `chunkText` on results
- `src/types.ts`: adds optional `chunkText` field to `SearchResult` and `SearchResultChunk`
- `src/mcp/server.ts`: minor update to surface `chunkText` in MCP tool responses
- `tests/text-utils.test.ts`: 9 new tests covering the excerpt selection logic, word boundary handling, and fallback behaviour
- `tests/search-engine-extended.test.ts`: 8 new tests verifying query-aware excerpt integration and `chunkText` presence on results

## Testing

All 314 tests pass. Typechecks clean. The new tests cover keyword clustering, tie-breaking, partial word handling, and the pure-semantic-match fallback.