### PR TITLE
feat(playground): add interactive ranking tuner to dev playground

### DIFF
--- a/src/playground/playground.html
+++ b/src/playground/playground.html
@@ -38,6 +38,35 @@
   .empty { text-align: center; padding: 3rem; color: #999; }
   .loading { text-align: center; padding: 2rem; color: #999; }
   .hidden { display: none; }
+
+  /* Ranking Tuner */
+  .tuner { margin-bottom: 1.5rem; border: 1px solid #e0e0e0; border-radius: 8px; background: #fff; }
+  .tuner > summary { padding: 0.75rem 1rem; font-weight: 600; font-size: 0.95rem; cursor: pointer; color: #16213e; user-select: none; }
+  .tuner > summary:hover { color: #4361ee; }
+  .tuner-body { padding: 0.5rem 1rem 1rem; }
+  .tuner-actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; }
+  .tuner-actions button { padding: 0.35rem 0.75rem; font-size: 0.8rem; border: 1px solid #ccc; border-radius: 4px; background: #fff; cursor: pointer; color: #555; }
+  .tuner-actions button:hover { border-color: #4361ee; color: #4361ee; }
+  .tuner-group { margin-bottom: 0.5rem; border: 1px solid #eee; border-radius: 6px; }
+  .tuner-group > summary { padding: 0.5rem 0.75rem; font-size: 0.85rem; font-weight: 600; cursor: pointer; color: #444; user-select: none; }
+  .tuner-group[open] { margin-bottom: 0.75rem; }
+  .tuner-group-body { padding: 0.25rem 0.75rem 0.5rem; }
+  .tuner-row { display: grid; grid-template-columns: 140px 1fr 70px 24px; gap: 8px; align-items: center; margin-bottom: 0.35rem; }
+  .tuner-row label { font-size: 0.8rem; color: #555; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .tuner-row label.modified { color: #4361ee; font-weight: 600; }
+  .tuner-row input[type="range"] { width: 100%; height: 6px; cursor: pointer; }
+  .tuner-row input[type="number"] { width: 70px; padding: 0.2rem 0.35rem; font-size: 0.8rem; border: 1px solid #ccc; border-radius: 4px; text-align: right; }
+  .tuner-row input[type="checkbox"] { width: 16px; height: 16px; cursor: pointer; }
+  .tuner-row .reset-btn { width: 20px; height: 20px; border: none; background: none; cursor: pointer; color: #999; font-size: 1rem; padding: 0; line-height: 1; visibility: hidden; }
+  .tuner-row .reset-btn.visible { visibility: visible; }
+  .tuner-row .reset-btn:hover { color: #4361ee; }
+  .tuner-bool-row { display: grid; grid-template-columns: 140px 1fr 24px; gap: 8px; align-items: center; margin-bottom: 0.35rem; }
+  .tuner-bool-row label { font-size: 0.8rem; color: #555; }
+  .tuner-bool-row label.modified { color: #4361ee; font-weight: 600; }
+  .tuner-bool-row .reset-btn { width: 20px; height: 20px; border: none; background: none; cursor: pointer; color: #999; font-size: 1rem; padding: 0; line-height: 1; visibility: hidden; }
+  .tuner-bool-row .reset-btn.visible { visibility: visible; }
+  .tuner-export { margin-top: 0.75rem; }
+  .tuner-export textarea { width: 100%; height: 120px; font-family: monospace; font-size: 0.8rem; padding: 0.5rem; border: 1px solid #ccc; border-radius: 6px; background: #f8f9fa; resize: vertical; }
 </style>
 </head>
 <body>
@@ -63,36 +92,274 @@
     </select>
   </label>
 </div>
+
+<details class="tuner" id="tunerPanel">
+  <summary>Ranking Tuner</summary>
+  <div class="tuner-body">
+    <div class="tuner-actions">
+      <button id="resetAll" type="button">Reset All</button>
+      <button id="exportConfig" type="button">Export Config</button>
+    </div>
+    <div id="tunerGroups"></div>
+    <div class="tuner-export hidden" id="exportArea">
+      <textarea id="exportText" readonly></textarea>
+    </div>
+  </div>
+</details>
+
 <div id="meta" class="meta"></div>
 <div id="results"></div>
 
 <script>
 (function() {
-  const qInput = document.getElementById('q');
-  const groupBySelect = document.getElementById('groupBy');
-  const topKSelect = document.getElementById('topK');
-  const resultsDiv = document.getElementById('results');
-  const metaDiv = document.getElementById('meta');
+  var qInput = document.getElementById('q');
+  var groupBySelect = document.getElementById('groupBy');
+  var topKSelect = document.getElementById('topK');
+  var resultsDiv = document.getElementById('results');
+  var metaDiv = document.getElementById('meta');
+  var tunerGroupsDiv = document.getElementById('tunerGroups');
+  var exportArea = document.getElementById('exportArea');
+  var exportText = document.getElementById('exportText');
 
-  let debounceTimer = null;
+  var debounceTimer = null;
+  var requestId = 0;
+  var baselineConfig = null;
+  var tunerParams = [];
+
+  var PARAM_DEFS = [
+    { group: 'Thresholds', key: 'ranking.minScore', label: 'minScore', min: 0, max: 1, step: 0.01 },
+    { group: 'Thresholds', key: 'ranking.scoreGapThreshold', label: 'scoreGapThreshold', min: 0, max: 1, step: 0.01 },
+    { group: 'Thresholds', key: 'ranking.minChunkScoreRatio', label: 'minChunkScoreRatio', min: 0, max: 1, step: 0.01 },
+    { group: 'Boosts', key: 'ranking.enableIncomingLinkBoost', label: 'incomingLinkBoost', type: 'bool' },
+    { group: 'Boosts', key: 'ranking.enableDepthBoost', label: 'depthBoost', type: 'bool' },
+    { group: 'Weights', key: 'ranking.weights.incomingLinks', label: 'incomingLinks', min: 0, max: 1, step: 0.01 },
+    { group: 'Weights', key: 'ranking.weights.depth', label: 'depth', min: 0, max: 1, step: 0.01 },
+    { group: 'Weights', key: 'ranking.weights.aggregation', label: 'aggregation', min: 0, max: 1, step: 0.01 },
+    { group: 'Weights', key: 'ranking.weights.titleMatch', label: 'titleMatch', min: 0, max: 1, step: 0.01 },
+    { group: 'Aggregation', key: 'ranking.aggregationCap', label: 'aggregationCap', min: 1, max: 20, step: 1 },
+    { group: 'Aggregation', key: 'ranking.aggregationDecay', label: 'aggregationDecay', min: 0, max: 1, step: 0.01 },
+    { group: 'Search', key: 'search.pageSearchWeight', label: 'pageSearchWeight', min: 0, max: 1, step: 0.01 }
+  ];
+
+  function getNestedValue(obj, path) {
+    var parts = path.split('.');
+    var v = obj;
+    for (var i = 0; i < parts.length; i++) {
+      if (v == null) return undefined;
+      v = v[parts[i]];
+    }
+    return v;
+  }
+
+  function setNestedValue(obj, path, value) {
+    var parts = path.split('.');
+    var cur = obj;
+    for (var i = 0; i < parts.length - 1; i++) {
+      if (!cur[parts[i]]) cur[parts[i]] = {};
+      cur = cur[parts[i]];
+    }
+    cur[parts[parts.length - 1]] = value;
+  }
+
+  function initTuner(config) {
+    baselineConfig = config;
+    var groups = {};
+    PARAM_DEFS.forEach(function(def) {
+      if (!groups[def.group]) groups[def.group] = [];
+      groups[def.group].push(def);
+    });
+
+    var html = '';
+    Object.keys(groups).forEach(function(groupName) {
+      html += '<details class="tuner-group" open>';
+      html += '<summary>' + groupName + '</summary>';
+      html += '<div class="tuner-group-body">';
+      groups[groupName].forEach(function(def) {
+        var val = getNestedValue(config, def.key);
+        if (def.type === 'bool') {
+          html += '<div class="tuner-bool-row" data-key="' + def.key + '">';
+          html += '<label>' + def.label + '</label>';
+          html += '<input type="checkbox"' + (val ? ' checked' : '') + ' data-param="' + def.key + '">';
+          html += '<button class="reset-btn" title="Reset" data-reset="' + def.key + '">\u21BA</button>';
+          html += '</div>';
+        } else {
+          html += '<div class="tuner-row" data-key="' + def.key + '">';
+          html += '<label>' + def.label + '</label>';
+          html += '<input type="range" min="' + def.min + '" max="' + def.max + '" step="' + def.step + '" value="' + val + '" data-param="' + def.key + '">';
+          html += '<input type="number" min="' + def.min + '" max="' + def.max + '" step="' + def.step + '" value="' + val + '" data-num="' + def.key + '">';
+          html += '<button class="reset-btn" title="Reset" data-reset="' + def.key + '">\u21BA</button>';
+          html += '</div>';
+        }
+      });
+      html += '</div></details>';
+    });
+    tunerGroupsDiv.innerHTML = html;
+
+    // Wire events
+    tunerGroupsDiv.addEventListener('input', function(e) {
+      var param = e.target.getAttribute('data-param');
+      var num = e.target.getAttribute('data-num');
+      if (param) {
+        // Slider or checkbox changed — sync number input
+        var row = e.target.closest('[data-key]');
+        if (row && e.target.type === 'range') {
+          var numInput = row.querySelector('[data-num]');
+          if (numInput) numInput.value = e.target.value;
+        }
+        updateModifiedState(param);
+        scheduleSearch();
+      } else if (num) {
+        // Number input changed — sync slider
+        var row = e.target.closest('[data-key]');
+        if (row) {
+          var rangeInput = row.querySelector('[data-param]');
+          if (rangeInput) rangeInput.value = e.target.value;
+        }
+        updateModifiedState(num);
+        scheduleSearch();
+      }
+    });
+
+    tunerGroupsDiv.addEventListener('change', function(e) {
+      var param = e.target.getAttribute('data-param');
+      if (param && e.target.type === 'checkbox') {
+        updateModifiedState(param);
+        scheduleSearch();
+      }
+    });
+
+    tunerGroupsDiv.addEventListener('click', function(e) {
+      var resetKey = e.target.getAttribute('data-reset');
+      if (resetKey) {
+        resetParam(resetKey);
+        scheduleSearch();
+      }
+    });
+  }
+
+  function updateModifiedState(key) {
+    var baseline = getNestedValue(baselineConfig, key);
+    var row = tunerGroupsDiv.querySelector('[data-key="' + key + '"]');
+    if (!row) return;
+    var input = row.querySelector('[data-param="' + key + '"]');
+    if (!input) return;
+    var current = input.type === 'checkbox' ? input.checked : parseFloat(input.value);
+    var isModified = current !== baseline;
+    var label = row.querySelector('label');
+    var resetBtn = row.querySelector('.reset-btn');
+    if (label) label.classList.toggle('modified', isModified);
+    if (resetBtn) resetBtn.classList.toggle('visible', isModified);
+  }
+
+  function resetParam(key) {
+    var baseline = getNestedValue(baselineConfig, key);
+    var row = tunerGroupsDiv.querySelector('[data-key="' + key + '"]');
+    if (!row) return;
+    var input = row.querySelector('[data-param="' + key + '"]');
+    if (!input) return;
+    if (input.type === 'checkbox') {
+      input.checked = baseline;
+    } else {
+      input.value = baseline;
+      var numInput = row.querySelector('[data-num]');
+      if (numInput) numInput.value = baseline;
+    }
+    updateModifiedState(key);
+  }
+
+  function resetAll() {
+    PARAM_DEFS.forEach(function(def) {
+      resetParam(def.key);
+    });
+    exportArea.classList.add('hidden');
+    scheduleSearch();
+  }
+
+  function collectOverrides() {
+    var overrides = {};
+    PARAM_DEFS.forEach(function(def) {
+      var row = tunerGroupsDiv.querySelector('[data-key="' + def.key + '"]');
+      if (!row) return;
+      var input = row.querySelector('[data-param="' + def.key + '"]');
+      if (!input) return;
+      var val = def.type === 'bool' ? input.checked : parseFloat(input.value);
+      setNestedValue(overrides, def.key, val);
+    });
+    return overrides;
+  }
+
+  function collectChangedOverrides() {
+    var overrides = {};
+    var hasChanges = false;
+    PARAM_DEFS.forEach(function(def) {
+      var row = tunerGroupsDiv.querySelector('[data-key="' + def.key + '"]');
+      if (!row) return;
+      var input = row.querySelector('[data-param="' + def.key + '"]');
+      if (!input) return;
+      var current = def.type === 'bool' ? input.checked : parseFloat(input.value);
+      var baseline = getNestedValue(baselineConfig, def.key);
+      if (current !== baseline) {
+        setNestedValue(overrides, def.key, current);
+        hasChanges = true;
+      }
+    });
+    return hasChanges ? overrides : null;
+  }
+
+  function exportConfig() {
+    var changed = collectChangedOverrides();
+    if (!changed) {
+      exportArea.classList.remove('hidden');
+      exportText.value = '// No parameters have been changed from defaults.';
+      return;
+    }
+
+    var lines = [];
+    if (changed.ranking) {
+      lines.push('ranking: {');
+      var r = changed.ranking;
+      var simpleKeys = ['enableIncomingLinkBoost', 'enableDepthBoost', 'aggregationCap', 'aggregationDecay', 'minChunkScoreRatio', 'minScore', 'scoreGapThreshold'];
+      simpleKeys.forEach(function(k) {
+        if (r[k] !== undefined) lines.push('  ' + k + ': ' + JSON.stringify(r[k]) + ',');
+      });
+      if (r.weights) {
+        lines.push('  weights: {');
+        Object.keys(r.weights).forEach(function(wk) {
+          lines.push('    ' + wk + ': ' + r.weights[wk] + ',');
+        });
+        lines.push('  },');
+      }
+      lines.push('},');
+    }
+    if (changed.search) {
+      lines.push('search: {');
+      Object.keys(changed.search).forEach(function(sk) {
+        lines.push('  ' + sk + ': ' + changed.search[sk] + ',');
+      });
+      lines.push('},');
+    }
+
+    exportArea.classList.remove('hidden');
+    exportText.value = lines.join('\n');
+  }
 
   // Read initial state from URL
-  const params = new URLSearchParams(window.location.search);
+  var params = new URLSearchParams(window.location.search);
   if (params.get('q')) qInput.value = params.get('q');
   if (params.get('groupBy')) groupBySelect.value = params.get('groupBy');
   if (params.get('topK')) topKSelect.value = params.get('topK');
 
   function updateUrl() {
-    const p = new URLSearchParams();
+    var p = new URLSearchParams();
     if (qInput.value) p.set('q', qInput.value);
     if (groupBySelect.value !== 'page') p.set('groupBy', groupBySelect.value);
     if (topKSelect.value !== '10') p.set('topK', topKSelect.value);
-    const qs = p.toString();
+    var qs = p.toString();
     history.replaceState(null, '', qs ? '?' + qs : window.location.pathname);
   }
 
-  async function doSearch() {
-    const query = qInput.value.trim();
+  function doSearch() {
+    var query = qInput.value.trim();
     updateUrl();
     if (!query) {
       resultsDiv.innerHTML = '<div class="empty">Enter a query to search</div>';
@@ -102,35 +369,41 @@
 
     resultsDiv.innerHTML = '<div class="loading">Searching...</div>';
 
-    try {
-      const body = {
-        q: query,
-        topK: parseInt(topKSelect.value, 10),
-        groupBy: groupBySelect.value,
-        debug: true
-      };
+    var thisRequestId = ++requestId;
+    var body = {
+      q: query,
+      topK: parseInt(topKSelect.value, 10),
+      groupBy: groupBySelect.value,
+      debug: true
+    };
 
-      const res = await fetch('/_searchsocket/search', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body)
-      });
-
-      if (!res.ok) {
-        const err = await res.text();
-        resultsDiv.innerHTML = '<div class="empty">Error: ' + escapeHtml(err) + '</div>';
-        return;
-      }
-
-      const data = await res.json();
-      renderResults(data);
-    } catch (err) {
-      resultsDiv.innerHTML = '<div class="empty">Network error: ' + escapeHtml(err.message) + '</div>';
+    if (baselineConfig) {
+      body.rankingOverrides = collectOverrides();
     }
+
+    fetch('/_searchsocket/search', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    }).then(function(res) {
+      if (thisRequestId !== requestId) return;
+      if (!res.ok) {
+        return res.text().then(function(err) {
+          resultsDiv.innerHTML = '<div class="empty">Error: ' + escapeHtml(err) + '</div>';
+        });
+      }
+      return res.json().then(function(data) {
+        if (thisRequestId !== requestId) return;
+        renderResults(data);
+      });
+    }).catch(function(err) {
+      if (thisRequestId !== requestId) return;
+      resultsDiv.innerHTML = '<div class="empty">Network error: ' + escapeHtml(err.message) + '</div>';
+    });
   }
 
   function escapeHtml(str) {
-    const d = document.createElement('div');
+    var d = document.createElement('div');
     d.textContent = str;
     return d.innerHTML;
   }
@@ -144,7 +417,7 @@
     }
 
     resultsDiv.innerHTML = data.results.map(function(r, i) {
-      let html = '<div class="result">';
+      var html = '<div class="result">';
       html += '<div class="result-header">';
       html += '<div><div class="result-title">' + escapeHtml(r.title) + '</div>';
       html += '<div class="result-url">' + escapeHtml(r.url) + '</div></div>';
@@ -214,6 +487,19 @@
   qInput.addEventListener('input', scheduleSearch);
   groupBySelect.addEventListener('change', scheduleSearch);
   topKSelect.addEventListener('change', scheduleSearch);
+
+  document.getElementById('resetAll').addEventListener('click', resetAll);
+  document.getElementById('exportConfig').addEventListener('click', exportConfig);
+
+  // Fetch config and initialize tuner
+  fetch('/_searchsocket/config').then(function(res) {
+    if (res.ok) return res.json();
+    return null;
+  }).then(function(config) {
+    if (config) initTuner(config);
+  }).catch(function() {
+    // Config endpoint not available — tuner stays empty
+  });
 
   // Trigger initial search if query is present
   if (qInput.value.trim()) doSearch();

--- a/src/playground/server.ts
+++ b/src/playground/server.ts
@@ -41,6 +41,24 @@ export async function runPlaygroundServer(
     res.type("html").send(playgroundHtml);
   });
 
+  app.get("/_searchsocket/config", (_req: Request, res: Response) => {
+    res.json({
+      ranking: {
+        enableIncomingLinkBoost: config.ranking.enableIncomingLinkBoost,
+        enableDepthBoost: config.ranking.enableDepthBoost,
+        aggregationCap: config.ranking.aggregationCap,
+        aggregationDecay: config.ranking.aggregationDecay,
+        minChunkScoreRatio: config.ranking.minChunkScoreRatio,
+        minScore: config.ranking.minScore,
+        scoreGapThreshold: config.ranking.scoreGapThreshold,
+        weights: { ...config.ranking.weights },
+      },
+      search: {
+        pageSearchWeight: config.search.pageSearchWeight,
+      },
+    });
+  });
+
   app.post("/_searchsocket/search", async (req: Request, res: Response) => {
     try {
       const searchEngine = await getEngine();
@@ -58,7 +76,10 @@ export async function runPlaygroundServer(
         pathPrefix: typeof body.pathPrefix === "string" ? body.pathPrefix : undefined,
         tags: Array.isArray(body.tags) ? body.tags : undefined,
         groupBy: body.groupBy === "page" || body.groupBy === "chunk" ? body.groupBy : undefined,
-        debug: body.debug === true
+        debug: body.debug === true,
+        rankingOverrides: body.rankingOverrides && typeof body.rankingOverrides === "object"
+          ? body.rankingOverrides as Record<string, unknown>
+          : undefined,
       });
 
       res.json(result);

--- a/src/search/engine.ts
+++ b/src/search/engine.ts
@@ -10,6 +10,7 @@ import { GeminiEmbedder } from "../vector/gemini";
 import { rankHits, aggregateByPage, trimByScoreGap, mergePageAndChunkResults } from "./ranking";
 import type {
   PageHit,
+  RankingOverrides,
   RelatedPage,
   RelatedPagesResult,
   ResolvedSearchSocketConfig,
@@ -25,6 +26,27 @@ import type { RankedHit, PageResult } from "./ranking";
 import { diceScore, compositeScore, dominantRelationshipType } from "./related-pages";
 import { toSnippet, queryAwareExcerpt } from "../utils/text";
 
+const rankingOverridesSchema = z.object({
+  ranking: z.object({
+    enableIncomingLinkBoost: z.boolean().optional(),
+    enableDepthBoost: z.boolean().optional(),
+    aggregationCap: z.number().int().positive().optional(),
+    aggregationDecay: z.number().min(0).max(1).optional(),
+    minChunkScoreRatio: z.number().min(0).max(1).optional(),
+    minScore: z.number().min(0).max(1).optional(),
+    scoreGapThreshold: z.number().min(0).max(1).optional(),
+    weights: z.object({
+      incomingLinks: z.number().optional(),
+      depth: z.number().optional(),
+      aggregation: z.number().optional(),
+      titleMatch: z.number().optional(),
+    }).optional(),
+  }).optional(),
+  search: z.object({
+    pageSearchWeight: z.number().min(0).max(1).optional(),
+  }).optional(),
+}).optional();
+
 const requestSchema = z.object({
   q: z.string().trim().min(1),
   topK: z.number().int().positive().max(100).optional(),
@@ -33,7 +55,8 @@ const requestSchema = z.object({
   tags: z.array(z.string()).optional(),
   groupBy: z.enum(["page", "chunk"]).optional(),
   maxSubResults: z.number().int().positive().max(20).optional(),
-  debug: z.boolean().optional()
+  debug: z.boolean().optional(),
+  rankingOverrides: rankingOverridesSchema,
 });
 
 const MAX_SITE_STRUCTURE_PAGES = 2000;
@@ -111,6 +134,27 @@ export function buildTree(
   return root;
 }
 
+function mergeRankingOverrides(
+  base: ResolvedSearchSocketConfig,
+  overrides: RankingOverrides
+): ResolvedSearchSocketConfig {
+  return {
+    ...base,
+    search: {
+      ...base.search,
+      ...overrides.search,
+    },
+    ranking: {
+      ...base.ranking,
+      ...overrides.ranking,
+      weights: {
+        ...base.ranking.weights,
+        ...overrides.ranking?.weights,
+      },
+    },
+  };
+}
+
 export interface SearchEngineOptions {
   cwd?: string;
   configPath?: string;
@@ -165,6 +209,11 @@ export class SearchEngine {
     const input = parsed.data;
     const totalStart = process.hrtime.bigint();
 
+    // Apply ranking overrides only when debug mode is enabled
+    const effectiveConfig = (input.debug && input.rankingOverrides)
+      ? mergeRankingOverrides(this.config, input.rankingOverrides)
+      : this.config;
+
     const resolvedScope = resolveScope(this.config, input.scope);
 
     const topK = input.topK ?? 10;
@@ -175,7 +224,7 @@ export class SearchEngine {
       ? Math.max(topK * 10, 50)
       : Math.max(50, topK);
 
-    const useDualSearch = this.config.search.dualSearch && groupByPage;
+    const useDualSearch = effectiveConfig.search.dualSearch && groupByPage;
 
     // Embed the query text via Gemini
     const queryVector = await this.embedder.embedQuery(input.q);
@@ -239,8 +288,8 @@ export class SearchEngine {
       const filteredChunks = applyPostFilters(chunkHits);
       const filteredPages = applyPagePostFilters(pageHits);
 
-      const rankedChunks = rankHits(filteredChunks, this.config, input.q, input.debug);
-      ranked = mergePageAndChunkResults(filteredPages, rankedChunks, this.config);
+      const rankedChunks = rankHits(filteredChunks, effectiveConfig, input.q, input.debug);
+      ranked = mergePageAndChunkResults(filteredPages, rankedChunks, effectiveConfig);
     } else {
       // Single search
       const fetchMultiplier = (pathPrefix || filterTags) ? 2 : 1;
@@ -251,11 +300,11 @@ export class SearchEngine {
         resolvedScope
       );
       const filtered = applyPostFilters(hits);
-      ranked = rankHits(filtered, this.config, input.q, input.debug);
+      ranked = rankHits(filtered, effectiveConfig, input.q, input.debug);
     }
     const searchMs = hrTimeMs(searchStart);
 
-    const results = this.buildResults(ranked, topK, groupByPage, maxSubResults, input.q, input.debug);
+    const results = this.buildResults(ranked, topK, groupByPage, maxSubResults, input.q, input.debug, effectiveConfig);
 
     return {
       q: input.q,
@@ -279,11 +328,12 @@ export class SearchEngine {
     return snippet || "";
   }
 
-  private buildResults(ordered: RankedHit[], topK: number, groupByPage: boolean, maxSubResults: number, query?: string, debug?: boolean): SearchResult[] {
+  private buildResults(ordered: RankedHit[], topK: number, groupByPage: boolean, maxSubResults: number, query?: string, debug?: boolean, config?: ResolvedSearchSocketConfig): SearchResult[] {
+    const cfg = config ?? this.config;
     if (groupByPage) {
-      let pages = aggregateByPage(ordered, this.config);
-      pages = trimByScoreGap(pages, this.config);
-      const minRatio = this.config.ranking.minChunkScoreRatio;
+      let pages = aggregateByPage(ordered, cfg);
+      pages = trimByScoreGap(pages, cfg);
+      const minRatio = cfg.ranking.minChunkScoreRatio;
       return pages.slice(0, topK).map((page) => {
         const bestScore = page.bestChunk.finalScore;
         const minChunkScore = Number.isFinite(bestScore) ? bestScore * minRatio : Number.NEGATIVE_INFINITY;
@@ -315,7 +365,7 @@ export class SearchEngine {
       });
     } else {
       let filtered = ordered;
-      const minScore = this.config.ranking.minScore;
+      const minScore = cfg.ranking.minScore;
       if (minScore > 0) {
         filtered = ordered.filter((entry) => entry.finalScore >= minScore);
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -439,6 +439,27 @@ export interface ScopeInfo {
   documentCount?: number;
 }
 
+export interface RankingOverrides {
+  ranking?: {
+    enableIncomingLinkBoost?: boolean;
+    enableDepthBoost?: boolean;
+    aggregationCap?: number;
+    aggregationDecay?: number;
+    minChunkScoreRatio?: number;
+    minScore?: number;
+    scoreGapThreshold?: number;
+    weights?: {
+      incomingLinks?: number;
+      depth?: number;
+      aggregation?: number;
+      titleMatch?: number;
+    };
+  };
+  search?: {
+    pageSearchWeight?: number;
+  };
+}
+
 export interface SearchRequest {
   q: string;
   topK?: number;
@@ -448,6 +469,7 @@ export interface SearchRequest {
   groupBy?: "page" | "chunk";
   maxSubResults?: number;
   debug?: boolean;
+  rankingOverrides?: RankingOverrides;
 }
 
 export interface ScoreBreakdown {

--- a/tests/playground-server.test.ts
+++ b/tests/playground-server.test.ts
@@ -35,7 +35,26 @@ const mocks = vi.hoisted(() => {
 
   const loadConfig = vi.fn().mockResolvedValue({
     project: { id: "test" },
-    upstash: { urlEnv: "UPSTASH_URL", tokenEnv: "UPSTASH_TOKEN" }
+    upstash: { urlEnv: "UPSTASH_URL", tokenEnv: "UPSTASH_TOKEN" },
+    ranking: {
+      enableIncomingLinkBoost: true,
+      enableDepthBoost: true,
+      aggregationCap: 5,
+      aggregationDecay: 0.5,
+      minChunkScoreRatio: 0.5,
+      minScore: 0.3,
+      scoreGapThreshold: 0.4,
+      weights: {
+        incomingLinks: 0.05,
+        depth: 0.03,
+        aggregation: 0.1,
+        titleMatch: 0.15
+      }
+    },
+    search: {
+      dualSearch: true,
+      pageSearchWeight: 0.3
+    }
   });
 
   return { app, expressFn, serverInstance, searchFn, createEngine, loadConfig };
@@ -114,6 +133,45 @@ describe("runPlaygroundServer", () => {
 
     expect(res.status).toHaveBeenCalledWith(400);
     expect(errorJsonFn).toHaveBeenCalledWith({ error: "Missing or empty 'q' field" });
+  });
+
+  it("GET /_searchsocket/config returns tunable ranking parameters", async () => {
+    await runPlaygroundServer({ cwd: "/tmp", port: 3337 });
+
+    const getHandler = mocks.app.get.mock.calls.find(
+      (call: unknown[]) => call[0] === "/_searchsocket/config"
+    )?.[1] as (req: unknown, res: { json: (d: unknown) => void }) => void;
+
+    expect(getHandler).toBeDefined();
+
+    const jsonFn = vi.fn();
+    getHandler({}, { json: jsonFn });
+
+    expect(jsonFn).toHaveBeenCalledTimes(1);
+    const configData = jsonFn.mock.calls[0]![0] as Record<string, unknown>;
+    expect(configData).toHaveProperty("ranking");
+    expect(configData).toHaveProperty("search");
+  });
+
+  it("POST /_searchsocket/search forwards rankingOverrides", async () => {
+    await runPlaygroundServer({ cwd: "/tmp", port: 3337 });
+
+    const postHandler = mocks.app.post.mock.calls.find(
+      (call: unknown[]) => call[0] === "/_searchsocket/search"
+    )?.[1] as (req: { body: Record<string, unknown> }, res: { json: (d: unknown) => void; status: (n: number) => { json: (d: unknown) => void } }) => Promise<void>;
+
+    const jsonFn = vi.fn();
+    const res = { json: jsonFn, status: vi.fn(() => ({ json: vi.fn() })) };
+    const overrides = { ranking: { minScore: 0.1 } };
+    await postHandler({ body: { q: "test", debug: true, rankingOverrides: overrides } }, res);
+
+    expect(mocks.searchFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: "test",
+        debug: true,
+        rankingOverrides: overrides
+      })
+    );
   });
 
   it("close() resolves cleanly", async () => {

--- a/tests/search-engine-extended.test.ts
+++ b/tests/search-engine-extended.test.ts
@@ -909,6 +909,177 @@ describe("SearchEngine - maxSubResults", () => {
   });
 });
 
+describe("SearchEngine - ranking overrides", () => {
+  it("applies ranking overrides when debug is true", async () => {
+    const cwd = await makeTempCwd();
+    const config = createDefaultConfig("searchsocket-engine-test");
+    // Default minScore is 0.3 — hits at 0.25 would normally be filtered out
+    config.ranking.minScore = 0.3;
+    config.ranking.scoreGapThreshold = 0;
+
+    const hits: VectorHit[] = [
+      { ...makeHit("chunk-1", "/page"), score: 0.25 }
+    ];
+
+    const engine = await SearchEngine.create({
+      cwd,
+      config,
+      store: createMockStore(hits),
+      embedder: createMockEmbedder()
+    });
+
+    // Without overrides: filtered out by minScore
+    const resultDefault = await engine.search({ q: "test", topK: 10, groupBy: "chunk" });
+    expect(resultDefault.results.length).toBe(0);
+
+    // With overrides: minScore=0 lets it through
+    const resultOverridden = await engine.search({
+      q: "test",
+      topK: 10,
+      groupBy: "chunk",
+      debug: true,
+      rankingOverrides: { ranking: { minScore: 0 } }
+    });
+    expect(resultOverridden.results.length).toBe(1);
+  });
+
+  it("ignores ranking overrides when debug is false", async () => {
+    const cwd = await makeTempCwd();
+    const config = createDefaultConfig("searchsocket-engine-test");
+    config.ranking.minScore = 0.3;
+    config.ranking.scoreGapThreshold = 0;
+
+    const hits: VectorHit[] = [
+      { ...makeHit("chunk-1", "/page"), score: 0.25 }
+    ];
+
+    const engine = await SearchEngine.create({
+      cwd,
+      config,
+      store: createMockStore(hits),
+      embedder: createMockEmbedder()
+    });
+
+    // debug: false — overrides should be ignored, so minScore 0.3 still applies
+    const result = await engine.search({
+      q: "test",
+      topK: 10,
+      groupBy: "chunk",
+      debug: false,
+      rankingOverrides: { ranking: { minScore: 0 } }
+    });
+    expect(result.results.length).toBe(0);
+  });
+
+  it("does not mutate base config across sequential calls", async () => {
+    const cwd = await makeTempCwd();
+    const config = createDefaultConfig("searchsocket-engine-test");
+    config.ranking.minScore = 0.3;
+    config.ranking.scoreGapThreshold = 0;
+
+    const hits: VectorHit[] = [
+      { ...makeHit("chunk-1", "/page"), score: 0.25 }
+    ];
+
+    const engine = await SearchEngine.create({
+      cwd,
+      config,
+      store: createMockStore(hits),
+      embedder: createMockEmbedder()
+    });
+
+    // First call with override
+    await engine.search({
+      q: "test",
+      topK: 10,
+      groupBy: "chunk",
+      debug: true,
+      rankingOverrides: { ranking: { minScore: 0 } }
+    });
+
+    // Second call without overrides — should use original config
+    const result = await engine.search({ q: "test", topK: 10, groupBy: "chunk" });
+    expect(result.results.length).toBe(0); // still filtered by original minScore 0.3
+  });
+
+  it("applies partial overrides — only specified fields change", async () => {
+    const cwd = await makeTempCwd();
+    const config = createDefaultConfig("searchsocket-engine-test");
+    config.ranking.minScore = 0;
+    config.ranking.scoreGapThreshold = 0;
+
+    const hits: VectorHit[] = [
+      { ...makeHit("chunk-1", "/a"), score: 0.9 },
+      { ...makeHit("chunk-2", "/b"), score: 0.85 }
+    ];
+
+    const engine = await SearchEngine.create({
+      cwd,
+      config,
+      store: createMockStore(hits),
+      embedder: createMockEmbedder()
+    });
+
+    // Override only titleMatch weight — other weights should remain at defaults
+    const result = await engine.search({
+      q: "test",
+      topK: 10,
+      groupBy: "chunk",
+      debug: true,
+      rankingOverrides: { ranking: { weights: { titleMatch: 0.5 } } }
+    });
+
+    // Should still return results (search works with partial overrides)
+    expect(result.results.length).toBe(2);
+  });
+
+  it("overrides pageSearchWeight via search namespace", async () => {
+    const cwd = await makeTempCwd();
+    const config = createDefaultConfig("searchsocket-engine-test");
+    config.ranking.minScore = 0;
+    config.ranking.scoreGapThreshold = 0;
+
+    const chunkHits: VectorHit[] = [
+      { ...makeHit("chunk-1", "/docs"), score: 0.5 }
+    ];
+    const pageHits: PageHit[] = [
+      {
+        id: "/docs",
+        score: 1.0,
+        title: "Docs",
+        url: "/docs",
+        description: "Documentation",
+        tags: [],
+        depth: 1,
+        incomingLinks: 0,
+        routeFile: "src/routes/docs/+page.svelte"
+      }
+    ];
+
+    const store = createMockStore(chunkHits, pageHits);
+    const engine = await SearchEngine.create({ cwd, config, store, embedder: createMockEmbedder() });
+
+    // With default pageSearchWeight (0.3)
+    const resultDefault = await engine.search({ q: "docs", topK: 10, debug: true });
+
+    // With higher pageSearchWeight (0.8) — page score should have more influence
+    const resultOverridden = await engine.search({
+      q: "docs",
+      topK: 10,
+      debug: true,
+      rankingOverrides: { search: { pageSearchWeight: 0.8 } }
+    });
+
+    // Both should return results — the scores should differ due to different page weights
+    expect(resultDefault.results.length).toBeGreaterThan(0);
+    expect(resultOverridden.results.length).toBeGreaterThan(0);
+
+    // With higher pageSearchWeight, the blended score should be higher
+    // (chunk score 0.5 blended with page score 1.0 at weight 0.8 > weight 0.3)
+    expect(resultOverridden.results[0]!.score).toBeGreaterThan(resultDefault.results[0]!.score);
+  });
+});
+
 describe("SearchEngine - listPages", () => {
   it("returns empty pages when store has no pages", async () => {
     const cwd = await makeTempCwd();


### PR DESCRIPTION
## Summary

- Adds a live ranking tuner panel to the `/_searchsocket` playground served by `searchsocket dev`, with sliders for all 11 tunable ranking parameters
- The search engine now accepts temporary `rankingOverrides` in debug-mode requests, so slider changes reorder results instantly without touching config or restarting
- Includes an "Export Config" button that outputs the current slider values as a `ranking:` block ready to paste into `searchsocket.config.ts`

Resolves #54

## Changes

- `src/search/engine.ts` — `SearchEngine.search()` now accepts optional `rankingOverrides` merged on top of the loaded config when `debug: true`
- `src/types.ts` — added `rankingOverrides` field to `SearchOptions` and `RankingOverrides` type covering all tunable parameters
- `src/playground/server.ts` — passes `rankingOverrides` from the request body through to the search engine
- `src/playground/playground.html` — new collapsible tuner panel with sliders, live labels, reset-to-defaults, and config export
- `tests/search-engine-extended.test.ts` — 171-line test suite covering override application, partial overrides, debug-only enforcement, and boundary values
- `tests/playground-server.test.ts` — extended to cover the override passthrough in the server handler

## Testing

Full test suite passes. Typechecks clean. The override path is guarded behind `debug: true` so production search requests are unaffected.