### PR TITLE
refactor(vector): deprecate embedTexts and embedQuery on GeminiEmbedder

### DIFF
--- a/src/vector/gemini.ts
+++ b/src/vector/gemini.ts
@@ -67,6 +67,9 @@ export class GeminiEmbedder {
   /**
    * Embed an array of texts using the configured model.
    * Handles batching and rate limiting internally.
+   *
+   * @deprecated The indexing pipeline now uses Upstash built-in embedding via the `data` field.
+   * This method is retained for backwards compatibility. Use `embedImage()` for multimodal embedding.
    */
   async embedTexts(texts: string[], taskType?: string, titles?: string[]): Promise<number[][]> {
     if (texts.length === 0) return [];
@@ -132,6 +135,9 @@ export class GeminiEmbedder {
 
   /**
    * Embed a single query text using RETRIEVAL_QUERY task type.
+   *
+   * @deprecated The search pipeline no longer uses client-side query embedding.
+   * This method is retained for backwards compatibility.
    */
   async embedQuery(query: string): Promise<number[]> {
     const result = await this.embedTexts([query], "RETRIEVAL_QUERY");


### PR DESCRIPTION
## Summary

- Marks `embedTexts()` and `embedQuery()` on `GeminiEmbedder` as `@deprecated` since the indexing pipeline now passes raw text via the `data` field and lets Upstash handle embedding natively.
- `embedImage()` is unchanged — it's still used for optional image description generation.

Resolves #71

## Changes

- `src/vector/gemini.ts`: added `@deprecated` JSDoc tags to `embedTexts` and `embedQuery`, noting these are no longer called in the main pipeline path.

## Testing

The deprecation is purely a documentation marker — no runtime behaviour changes. Existing test suite passes without modification.