### PR TITLE
feat(mcp): allow anonymous access to the SvelteKit /api/mcp handle route

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -145,12 +145,21 @@ now produces a migration error. Tune ranking through `ranking.weights`.
 
 - `mcp.enable` (default `NODE_ENV !== "production"`) — mount the MCP endpoint on
   the SvelteKit handle.
-- `mcp.handle.apiKey` / `mcp.handle.apiKeyEnv` — **required** for the endpoint to
-  serve anything. MCP returns repository paths, a page's indexed markdown, and any
-  scope the caller names, so without a key the route answers 503.
+- `mcp.handle.apiKey` / `mcp.handle.apiKeyEnv` — required for the endpoint to
+  serve anything while `mcp.handle.access` is `private`. MCP returns repository
+  paths, a page's indexed markdown, and any scope the caller names, so without a
+  key the route answers 503.
+- `mcp.handle.access` (default `private`) — governs the **SvelteKit handle
+  route**. `public` serves callers that present no `Authorization` header
+  instead of refusing them, with `routeFile`, `chunkText` and `breakdown`
+  stripped from every tool result and the caller's `scope` ignored — the same
+  fields `api.exposeInternalFields` withholds from the browser API. A valid
+  bearer token still returns them, so an editing agent configured with the key
+  keeps source paths and a public agent does not. A wrong or malformed token is
+  still a 401 rather than a silent downgrade.
 - `mcp.access` (default `private`) — governs the **standalone** MCP server only:
   whether it binds to loopback or all interfaces. It has no effect on the
-  SvelteKit handle route, which always requires a key.
+  SvelteKit handle route, which is governed by `mcp.handle.access`.
 
 ## Ranking
 
@@ -179,12 +188,21 @@ now produces a migration error. Tune ranking through `ranking.weights`.
 
 - `mcp.enable` (default `NODE_ENV !== "production"`) — mount the MCP endpoint on
   the SvelteKit handle.
-- `mcp.handle.apiKey` / `mcp.handle.apiKeyEnv` — **required** for the endpoint to
-  serve anything. MCP returns repository paths, a page's indexed markdown, and any
-  scope the caller names, so without a key the route answers 503.
+- `mcp.handle.apiKey` / `mcp.handle.apiKeyEnv` — required for the endpoint to
+  serve anything while `mcp.handle.access` is `private`. MCP returns repository
+  paths, a page's indexed markdown, and any scope the caller names, so without a
+  key the route answers 503.
+- `mcp.handle.access` (default `private`) — governs the **SvelteKit handle
+  route**. `public` serves callers that present no `Authorization` header
+  instead of refusing them, with `routeFile`, `chunkText` and `breakdown`
+  stripped from every tool result and the caller's `scope` ignored — the same
+  fields `api.exposeInternalFields` withholds from the browser API. A valid
+  bearer token still returns them, so an editing agent configured with the key
+  keeps source paths and a public agent does not. A wrong or malformed token is
+  still a 401 rather than a silent downgrade.
 - `mcp.access` (default `private`) — governs the **standalone** MCP server only:
   whether it binds to loopback or all interfaces. It has no effect on the
-  SvelteKit handle route, which always requires a key.
+  SvelteKit handle route, which is governed by `mcp.handle.access`.
 
 ## Ranking weights
 
@@ -211,6 +229,8 @@ now produces a migration error. Tune ranking through `ranking.weights`.
 - `mcp.http.apiKey` (optional) — API key for HTTP transport
 - `mcp.http.apiKeyEnv` (optional) — env var for HTTP API key
 - `mcp.handle.path` (default `/api/mcp`) — SvelteKit handle endpoint path
+- `mcp.handle.access` (`public` | `private`, default `private`) — whether the
+  handle route serves anonymous callers a redacted result set
 - `mcp.handle.apiKey` (optional) — API key for handle endpoint
 - `mcp.handle.enableJsonResponse` (default `true`) — enable JSON response format
 

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -104,6 +104,7 @@ export function createDefaultConfig(projectId: string): ResolvedSearchSocketConf
       },
       handle: {
         path: "/api/mcp",
+        access: "private",
         enableJsonResponse: true
       }
     },

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -301,9 +301,13 @@ export function mergeConfig(cwd: string, rawConfig: SearchSocketConfig): Resolve
   }
 
   // `mcp.access` governs the standalone MCP server only — it decides whether
-  // that process binds to loopback or to all interfaces. The SvelteKit handle
-  // route has its own rule and always requires `mcp.handle.apiKey` /
-  // `apiKeyEnv`, so it needs no check here.
+  // that process binds to loopback or to all interfaces, so its public mode
+  // still has to have a key and that guard stays here.
+  //
+  // `mcp.handle.access` is a separate switch, enforced per request by the
+  // SvelteKit handler. Its public mode deliberately serves anonymous callers a
+  // redacted result set, so requiring a handle key at load time would defeat
+  // the setting outright — it gets no check here.
   if (merged.mcp.access === "public") {
     const resolvedKey = merged.mcp.http.apiKey
       ?? (merged.mcp.http.apiKeyEnv ? process.env[merged.mcp.http.apiKeyEnv] : undefined);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -180,6 +180,12 @@ export const searchSocketConfigSchema = z.object({
       handle: z
         .object({
           path: z.string().optional(),
+          /**
+           * Independent of the top-level `mcp.access`, which only governs the
+           * standalone server's bind address. "public" serves anonymous
+           * callers a redacted result set instead of refusing them.
+           */
+          access: z.enum(["public", "private"]).optional(),
           apiKey: z.string().min(1).optional(),
           /** Env var holding the key, so it need not be committed. */
           apiKeyEnv: z.string().min(1).optional(),

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { SearchEngine } from "../search/engine";
 import { SearchSocketError } from "../errors";
 import { loadConfig } from "../config/load";
+import { toPublicPage, toPublicRelatedPages, toPublicResults } from "../utils/redact";
 import type { ResolvedSearchSocketConfig } from "../types";
 
 /**
@@ -29,7 +30,36 @@ export interface McpServerOptions {
   apiKey?: string;
 }
 
-export function createServer(engine: SearchEngine): McpServer {
+export interface CreateServerOptions {
+  /**
+   * Strip repository paths and indexed section text from every tool result,
+   * and refuse a caller-supplied scope.
+   *
+   * Set by the SvelteKit handle route for an anonymous caller under
+   * `mcp.handle.access: "public"`. Defaults to false so the standalone stdio
+   * and HTTP servers — which are key-gated or loopback-bound — are unaffected.
+   */
+  redact?: boolean;
+}
+
+export function createServer(engine: SearchEngine, opts: CreateServerOptions = {}): McpServer {
+  const redact = opts.redact ?? false;
+
+  // An anonymous caller must not be able to name a scope. `resolveScope` takes
+  // any override it is given, so a guessed "staging" or a branch name would
+  // read content the site has not published — the same hole `api.allowedScopes`
+  // closes for the browser endpoint. The field stays in the input shape so the
+  // tool signature is stable across privilege levels; the value is dropped on
+  // the way to the engine, which is what actually holds the line.
+  const scopeInput = redact
+    ? z
+        .string()
+        .optional()
+        .describe("Ignored here: this endpoint serves the deployment's default scope only.")
+    : z.string().optional();
+  const requestedScope = (input: { scope?: string }): string | undefined =>
+    redact ? undefined : input.scope;
+
   const server = new McpServer({
     name: "searchsocket-mcp",
     // Was hardcoded at "0.2.0" and drifted from the package for five releases,
@@ -43,8 +73,9 @@ export function createServer(engine: SearchEngine): McpServer {
   server.registerTool(
     "search",
     {
-      description:
-        "Searches indexed site content using semantic similarity. Returns ranked results with url, title, snippet, chunkText (the matched section's indexed text, capped in length), score, and routeFile (source file path for editing). The highest-ranked results include their best-matching sections; lower-ranked results carry a page summary only. Set groupBy to 'chunk' to search sections directly. Use routeFile, when present, to locate the source file for editing; custom-record results have none. If snippets lack detail, call get_page with the result URL for the page's indexed markdown.",
+      description: redact
+        ? "Searches indexed site content using semantic similarity. Returns ranked results with url, title, snippet and score. The highest-ranked results include their best-matching sections; lower-ranked results carry a page summary only. Set groupBy to 'chunk' to search sections directly. If snippets lack detail, call get_page with the result URL for the page's indexed markdown."
+        : "Searches indexed site content using semantic similarity. Returns ranked results with url, title, snippet, chunkText (the matched section's indexed text, capped in length), score, and routeFile (source file path for editing). The highest-ranked results include their best-matching sections; lower-ranked results carry a page summary only. Set groupBy to 'chunk' to search sections directly. Use routeFile, when present, to locate the source file for editing; custom-record results have none. If snippets lack detail, call get_page with the result URL for the page's indexed markdown.",
       inputSchema: {
         query: z.string().min(1).describe("Search query. Use keywords or natural language, not full sentences."),
         topK: z.number().int().positive().max(100).optional().describe("Number of results to return (default: 10, max: 100)"),
@@ -52,14 +83,14 @@ export function createServer(engine: SearchEngine): McpServer {
         tags: z.array(z.string()).optional().describe("Filter results to pages matching all specified tags"),
         filters: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional().describe("Filter by structured page metadata (e.g. {\"version\": 2})"),
         groupBy: z.enum(["page", "chunk"]).optional().describe("'page' (default) groups chunks by page with sub-results; 'chunk' returns individual chunks"),
-        scope: z.string().optional()
+        scope: scopeInput
       }
     },
     async (input) => {
       const result = await engine.search({
         q: input.query,
         topK: input.topK,
-        scope: input.scope,
+        scope: requestedScope(input),
         pathPrefix: input.pathPrefix,
         tags: input.tags,
         filters: input.filters,
@@ -81,7 +112,11 @@ export function createServer(engine: SearchEngine): McpServer {
         content: [
           {
             type: "text",
-            text: JSON.stringify(result, null, 2)
+            text: JSON.stringify(
+              { ...result, results: toPublicResults(result.results, redact) },
+              null,
+              2
+            )
           }
         ]
       };
@@ -94,21 +129,22 @@ export function createServer(engine: SearchEngine): McpServer {
   server.registerTool(
     "get_page",
     {
-      description:
-        "Retrieves the indexed markdown and metadata for a page by its URL path. Use this after search when snippets lack the detail needed to answer a question. The markdown is reassembled from the indexed chunks: it is complete enough to read and reason about, but is NOT byte-exact source — it can contain section overlap and very long pages may be truncated. Read the file at routeFile when exact content matters. Do NOT use this for discovery — use search first.",
+      description: redact
+        ? "Retrieves the indexed markdown and metadata for a page by its URL path. Use this after search when snippets lack the detail needed to answer a question. The markdown is reassembled from the indexed chunks: it is complete enough to read and reason about, but is NOT byte-exact source — it can contain section overlap and very long pages may be truncated. Do NOT use this for discovery — use search first."
+        : "Retrieves the indexed markdown and metadata for a page by its URL path. Use this after search when snippets lack the detail needed to answer a question. The markdown is reassembled from the indexed chunks: it is complete enough to read and reason about, but is NOT byte-exact source — it can contain section overlap and very long pages may be truncated. Read the file at routeFile when exact content matters. Do NOT use this for discovery — use search first.",
       inputSchema: {
         path: z.string().min(1).describe("URL path of the page (e.g. '/docs/auth'). Use a URL from search results."),
-        scope: z.string().optional()
+        scope: scopeInput
       }
     },
     async (input) => {
       try {
-        const page = await engine.getPage(input.path, input.scope);
+        const page = await engine.getPage(input.path, requestedScope(input));
         return {
           content: [
             {
               type: "text",
-              text: JSON.stringify(page, null, 2)
+              text: JSON.stringify(toPublicPage(page, redact), null, 2)
             }
           ]
         };
@@ -136,7 +172,7 @@ export function createServer(engine: SearchEngine): McpServer {
           };
         }
 
-        const suggestions = await engine.search({ q: input.path, topK: 3, scope: input.scope });
+        const suggestions = await engine.search({ q: input.path, topK: 3, scope: requestedScope(input) });
         const similar = suggestions.results.map((r) => r.url);
         return {
           content: [
@@ -163,19 +199,19 @@ export function createServer(engine: SearchEngine): McpServer {
       inputSchema: {
         path: z.string().min(1).describe("URL path of the source page (e.g. '/docs/auth'). Use a URL from search results."),
         topK: z.number().int().positive().max(25).optional().describe("Number of related pages to return (default: 10, max: 25)"),
-        scope: z.string().optional()
+        scope: scopeInput
       }
     },
     async (input) => {
       const result = await engine.getRelatedPages(input.path, {
         topK: input.topK,
-        scope: input.scope
+        scope: requestedScope(input)
       });
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify(result, null, 2)
+            text: JSON.stringify(toPublicRelatedPages(result, redact), null, 2)
           }
         ]
       };

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -60,6 +60,38 @@ export function createServer(engine: SearchEngine, opts: CreateServerOptions = {
   const requestedScope = (input: { scope?: string }): string | undefined =>
     redact ? undefined : input.scope;
 
+  /**
+   * Keep an engine failure from narrating itself to an anonymous caller.
+   *
+   * The SDK turns a thrown error into an `isError` result carrying
+   * `error.message` verbatim, and those messages name internals — a missing
+   * scope env var reports the variable's name, a backend failure can carry a
+   * URL. That was fine while every caller held a key. A privileged caller still
+   * gets the real error, which its clients rely on for diagnosis.
+   */
+  const guard = async <T>(
+    operation: string,
+    run: () => Promise<T>
+  ): Promise<T | { isError: true; content: Array<{ type: "text"; text: string }> }> => {
+    if (!redact) return run();
+    try {
+      return await run();
+    } catch (error) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text:
+              `Could not complete '${operation}': ` +
+              `${error instanceof SearchSocketError ? error.code : "INTERNAL_ERROR"}. ` +
+              "This is a backend or configuration failure."
+          }
+        ]
+      };
+    }
+  };
+
   const server = new McpServer({
     name: "searchsocket-mcp",
     // Was hardcoded at "0.2.0" and drifted from the package for five releases,
@@ -86,41 +118,42 @@ export function createServer(engine: SearchEngine, opts: CreateServerOptions = {
         scope: scopeInput
       }
     },
-    async (input) => {
-      const result = await engine.search({
-        q: input.query,
-        topK: input.topK,
-        scope: requestedScope(input),
-        pathPrefix: input.pathPrefix,
-        tags: input.tags,
-        filters: input.filters,
-        groupBy: input.groupBy
-      });
+    async (input) =>
+      guard("search", async () => {
+        const result = await engine.search({
+          q: input.query,
+          topK: input.topK,
+          scope: requestedScope(input),
+          pathPrefix: input.pathPrefix,
+          tags: input.tags,
+          filters: input.filters,
+          groupBy: input.groupBy
+        });
 
-      if (result.results.length === 0) {
+        if (result.results.length === 0) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `No results found for "${input.query}". Try broader keywords or remove filters.`
+              }
+            ]
+          };
+        }
+
         return {
           content: [
             {
-              type: "text",
-              text: `No results found for "${input.query}". Try broader keywords or remove filters.`
+              type: "text" as const,
+              text: JSON.stringify(
+                { ...result, results: toPublicResults(result.results, redact) },
+                null,
+                2
+              )
             }
           ]
         };
-      }
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(
-              { ...result, results: toPublicResults(result.results, redact) },
-              null,
-              2
-            )
-          }
-        ]
-      };
-    }
+      })
   );
 
   // ---------------------------------------------------------------------------
@@ -137,55 +170,56 @@ export function createServer(engine: SearchEngine, opts: CreateServerOptions = {
         scope: scopeInput
       }
     },
-    async (input) => {
-      try {
-        const page = await engine.getPage(input.path, requestedScope(input));
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(toPublicPage(page, redact), null, 2)
-            }
-          ]
-        };
-      } catch (error) {
-        // Only a genuine miss falls back to suggestions. A backend outage or a
-        // rejected scope reported as "page not found" sent the client looking
-        // for a spelling mistake instead of surfacing the real failure.
-        // Suggestions are only meaningful for a genuine miss. Anything else —
-        // a backend outage, a refused scope, an unexpected throw — is reported
-        // as what it is, rather than sending the client hunting for a typo.
-        const isNotFound =
-          error instanceof SearchSocketError && error.code === "INVALID_REQUEST" && error.status === 404;
-        if (!isNotFound) {
+    async (input) =>
+      guard("get_page", async () => {
+        try {
+          const page = await engine.getPage(input.path, requestedScope(input));
           return {
-            isError: true,
             content: [
               {
-                type: "text",
-                text:
-                  `Could not retrieve '${input.path}': ` +
-                  `${error instanceof SearchSocketError ? error.code : "INTERNAL_ERROR"}. ` +
-                  "This is a backend or configuration failure, not a missing page."
+                type: "text" as const,
+                text: JSON.stringify(toPublicPage(page, redact), null, 2)
+              }
+            ]
+          };
+        } catch (error) {
+          // Only a genuine miss falls back to suggestions. A backend outage or a
+          // rejected scope reported as "page not found" sent the client looking
+          // for a spelling mistake instead of surfacing the real failure.
+          // Suggestions are only meaningful for a genuine miss. Anything else —
+          // a backend outage, a refused scope, an unexpected throw — is reported
+          // as what it is, rather than sending the client hunting for a typo.
+          const isNotFound =
+            error instanceof SearchSocketError && error.code === "INVALID_REQUEST" && error.status === 404;
+          if (!isNotFound) {
+            return {
+              isError: true as const,
+              content: [
+                {
+                  type: "text" as const,
+                  text:
+                    `Could not retrieve '${input.path}': ` +
+                    `${error instanceof SearchSocketError ? error.code : "INTERNAL_ERROR"}. ` +
+                    "This is a backend or configuration failure, not a missing page."
+                }
+              ]
+            };
+          }
+
+          const suggestions = await engine.search({ q: input.path, topK: 3, scope: requestedScope(input) });
+          const similar = suggestions.results.map((r) => r.url);
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: similar.length > 0
+                  ? `Page '${input.path}' not found. Similar pages: ${similar.join(", ")}`
+                  : `Page '${input.path}' not found. Use search to find the correct URL.`
               }
             ]
           };
         }
-
-        const suggestions = await engine.search({ q: input.path, topK: 3, scope: requestedScope(input) });
-        const similar = suggestions.results.map((r) => r.url);
-        return {
-          content: [
-            {
-              type: "text",
-              text: similar.length > 0
-                ? `Page '${input.path}' not found. Similar pages: ${similar.join(", ")}`
-                : `Page '${input.path}' not found. Use search to find the correct URL.`
-            }
-          ]
-        };
-      }
-    }
+      })
   );
 
   // ---------------------------------------------------------------------------
@@ -202,20 +236,21 @@ export function createServer(engine: SearchEngine, opts: CreateServerOptions = {
         scope: scopeInput
       }
     },
-    async (input) => {
-      const result = await engine.getRelatedPages(input.path, {
-        topK: input.topK,
-        scope: requestedScope(input)
-      });
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(toPublicRelatedPages(result, redact), null, 2)
-          }
-        ]
-      };
-    }
+    async (input) =>
+      guard("get_related_pages", async () => {
+        const result = await engine.getRelatedPages(input.path, {
+          topK: input.topK,
+          scope: requestedScope(input)
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(toPublicRelatedPages(result, redact), null, 2)
+            }
+          ]
+        };
+      })
   );
 
   return server;

--- a/src/sveltekit/handle.ts
+++ b/src/sveltekit/handle.ts
@@ -593,22 +593,6 @@ async function handleMcpRequest(
   // nothing more.
   const isPublic = access === "public";
 
-  // The transport owns the body stream — reading it here to measure it would
-  // leave nothing for `handleRequest` — so this bounds the declared length
-  // only, the same first check `handlePostSearch` makes. A client that omits
-  // content-length is not stopped by it; platform limits are the real backstop.
-  // Worth having anyway: until now every caller here had presented a key.
-  const declaredLength = Number(event.request.headers.get("content-length") ?? 0);
-  if (declaredLength > bodyLimit) {
-    return new Response(
-      JSON.stringify({
-        jsonrpc: "2.0",
-        error: { code: -32600, message: "Request body too large" },
-        id: null
-      }),
-      { status: 413, headers: { "content-type": "application/json" } }
-    );
-  }
 
   if (!apiKey && !isPublic) {
     return new Response(
@@ -653,15 +637,40 @@ async function handleMcpRequest(
     isAnonymous = true;
   } else {
     if (!apiKey) return unauthorized();
-    // The scheme name is case-insensitive per RFC 7235; the credential after it
-    // is not, and is compared byte-exact below.
-    if (!/^Bearer /i.test(authHeader)) return unauthorized();
+    // The scheme name is case-insensitive and may be followed by more than one
+    // space (RFC 7235 grammar is `1*SP`); the credential itself is neither, and
+    // is compared byte-exact below.
+    const bearer = /^Bearer +(.*)$/is.exec(authHeader);
+    if (!bearer) return unauthorized();
 
-    const token = authHeader.slice(7);
+    const token = bearer[1] ?? "";
     // `verifyApiKey` hashes both sides to equal-length digests before
     // comparing, so an attacker cannot learn the key's length from how long a
     // rejection takes — the previous inline length check leaked exactly that.
     if (token.length === 0 || !verifyApiKey(token, apiKey)) return unauthorized();
+  }
+
+  // Only now that the caller is entitled to the endpoint. Placing this before
+  // the checks above turned a private deployment's 503 into a 413 and told an
+  // unauthenticated caller the configured threshold.
+  //
+  // The transport owns the body stream — reading it here to measure it would
+  // leave nothing for `handleRequest` — so this bounds the declared length
+  // only, the same first check `handlePostSearch` makes. A client that omits
+  // content-length is not stopped by it; platform limits are the real backstop.
+  // Worth having anyway: until now every caller here had presented a key.
+  const declaredLength = Number(event.request.headers.get("content-length") ?? 0);
+  if (declaredLength > bodyLimit) {
+    return new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        // Implementation-defined server error, as used by the 405s above. The
+        // request is a structurally valid one, so -32600 would misreport it.
+        error: { code: -32000, message: "Request body too large" },
+        id: null
+      }),
+      { status: 413, headers: { "content-type": "application/json" } }
+    );
   }
 
   const transport = new WebStandardStreamableHTTPServerTransport({

--- a/src/sveltekit/handle.ts
+++ b/src/sveltekit/handle.ts
@@ -87,7 +87,10 @@ export function searchsocketHandle(options: SearchSocketHandleOptions = {}) {
         mcpApiKey =
           config.mcp.handle.apiKey ??
           (config.mcp.handle.apiKeyEnv ? process.env[config.mcp.handle.apiKeyEnv] : undefined);
-        mcpAccess = config.mcp.handle.access;
+        // `options.config` is handed through unmerged, so a config object built
+        // before this field existed arrives with `access` undefined. Only an
+        // exact "public" opts in; anything else stays private.
+        mcpAccess = config.mcp.handle.access === "public" ? "public" : "private";
         mcpEnableJsonResponse = config.mcp.handle.enableJsonResponse;
 
         if (config.llmsTxt.enable) {
@@ -144,7 +147,7 @@ export function searchsocketHandle(options: SearchSocketHandleOptions = {}) {
       const isMarkdownVariant = event.request.method === "GET" && event.url.pathname.endsWith(".md");
 
       if (mcpPath && event.url.pathname === mcpPath) {
-        return handleMcpRequest(event, mcpAccess, mcpApiKey, mcpEnableJsonResponse, getEngine);
+        return handleMcpRequest(event, mcpAccess, mcpApiKey, mcpEnableJsonResponse, bodyLimit, getEngine);
       }
       if (mcpPath) {
         // Config loaded and path matches neither endpoint
@@ -169,7 +172,7 @@ export function searchsocketHandle(options: SearchSocketHandleOptions = {}) {
         }
 
         if (mcpPath && event.url.pathname === mcpPath) {
-          return handleMcpRequest(event, mcpAccess, mcpApiKey, mcpEnableJsonResponse, getEngine);
+          return handleMcpRequest(event, mcpAccess, mcpApiKey, mcpEnableJsonResponse, bodyLimit, getEngine);
         }
         if (!(serveMarkdownVariants && isMarkdownVariant)) {
           return resolve(event);
@@ -225,7 +228,7 @@ export function searchsocketHandle(options: SearchSocketHandleOptions = {}) {
 
     // MCP endpoint handling
     if (mcpPath && event.url.pathname === mcpPath) {
-      return handleMcpRequest(event, mcpAccess, mcpApiKey, mcpEnableJsonResponse, getEngine);
+      return handleMcpRequest(event, mcpAccess, mcpApiKey, mcpEnableJsonResponse, bodyLimit, getEngine);
     }
     const targetPath = apiPath ?? config.api.path;
 
@@ -542,6 +545,7 @@ async function handleMcpRequest(
   access: "public" | "private",
   apiKey: string | undefined,
   enableJsonResponse: boolean,
+  bodyLimit: number,
   getEngine: () => Promise<SearchEngine>
 ): Promise<Response> {
   const method = event.request.method;
@@ -587,7 +591,26 @@ async function handleMcpRequest(
   // caller is served, but with the same fields stripped that the browser API
   // already withholds, so what it can reach is the site's published content and
   // nothing more.
-  if (!apiKey && access === "private") {
+  const isPublic = access === "public";
+
+  // The transport owns the body stream — reading it here to measure it would
+  // leave nothing for `handleRequest` — so this bounds the declared length
+  // only, the same first check `handlePostSearch` makes. A client that omits
+  // content-length is not stopped by it; platform limits are the real backstop.
+  // Worth having anyway: until now every caller here had presented a key.
+  const declaredLength = Number(event.request.headers.get("content-length") ?? 0);
+  if (declaredLength > bodyLimit) {
+    return new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        error: { code: -32600, message: "Request body too large" },
+        id: null
+      }),
+      { status: 413, headers: { "content-type": "application/json" } }
+    );
+  }
+
+  if (!apiKey && !isPublic) {
     return new Response(
       JSON.stringify({
         jsonrpc: "2.0",
@@ -626,11 +649,13 @@ async function handleMcpRequest(
   let isAnonymous = false;
 
   if (authHeader === null) {
-    if (access === "private") return unauthorized();
+    if (!isPublic) return unauthorized();
     isAnonymous = true;
   } else {
     if (!apiKey) return unauthorized();
-    if (!authHeader.startsWith("Bearer ")) return unauthorized();
+    // The scheme name is case-insensitive per RFC 7235; the credential after it
+    // is not, and is compared byte-exact below.
+    if (!/^Bearer /i.test(authHeader)) return unauthorized();
 
     const token = authHeader.slice(7);
     // `verifyApiKey` hashes both sides to equal-length digests before

--- a/src/sveltekit/handle.ts
+++ b/src/sveltekit/handle.ts
@@ -1,13 +1,13 @@
-import { timingSafeEqual } from "node:crypto";
 import fs from "node:fs/promises";
 import nodePath from "node:path";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { loadConfig, mergeConfig } from "../config/load";
 import { isServerless } from "../core/serverless";
 import { SearchSocketError, toErrorPayload } from "../errors";
-import { createServer as createMcpServer } from "../mcp/server";
+import { createServer as createMcpServer, verifyApiKey } from "../mcp/server";
 import { SearchEngine } from "../search/engine";
-import type { ResolvedSearchSocketConfig, SearchRequest, SearchResult, SearchSocketConfig } from "../types";
+import { toPublicPage, toPublicResults } from "../utils/redact";
+import type { ResolvedSearchSocketConfig, SearchRequest, SearchSocketConfig } from "../types";
 
 interface RateBucket {
   count: number;
@@ -57,6 +57,7 @@ export function searchsocketHandle(options: SearchSocketHandleOptions = {}) {
   let serveMarkdownVariants = false;
   let mcpPath: string | undefined;
   let mcpApiKey: string | undefined;
+  let mcpAccess: "public" | "private" = "private";
   let mcpEnableJsonResponse = true;
   let rateLimiter: InMemoryRateLimiter | null = null;
   let notConfigured = false;
@@ -86,6 +87,7 @@ export function searchsocketHandle(options: SearchSocketHandleOptions = {}) {
         mcpApiKey =
           config.mcp.handle.apiKey ??
           (config.mcp.handle.apiKeyEnv ? process.env[config.mcp.handle.apiKeyEnv] : undefined);
+        mcpAccess = config.mcp.handle.access;
         mcpEnableJsonResponse = config.mcp.handle.enableJsonResponse;
 
         if (config.llmsTxt.enable) {
@@ -142,7 +144,7 @@ export function searchsocketHandle(options: SearchSocketHandleOptions = {}) {
       const isMarkdownVariant = event.request.method === "GET" && event.url.pathname.endsWith(".md");
 
       if (mcpPath && event.url.pathname === mcpPath) {
-        return handleMcpRequest(event, mcpApiKey, mcpEnableJsonResponse, getEngine);
+        return handleMcpRequest(event, mcpAccess, mcpApiKey, mcpEnableJsonResponse, getEngine);
       }
       if (mcpPath) {
         // Config loaded and path matches neither endpoint
@@ -167,7 +169,7 @@ export function searchsocketHandle(options: SearchSocketHandleOptions = {}) {
         }
 
         if (mcpPath && event.url.pathname === mcpPath) {
-          return handleMcpRequest(event, mcpApiKey, mcpEnableJsonResponse, getEngine);
+          return handleMcpRequest(event, mcpAccess, mcpApiKey, mcpEnableJsonResponse, getEngine);
         }
         if (!(serveMarkdownVariants && isMarkdownVariant)) {
           return resolve(event);
@@ -223,7 +225,7 @@ export function searchsocketHandle(options: SearchSocketHandleOptions = {}) {
 
     // MCP endpoint handling
     if (mcpPath && event.url.pathname === mcpPath) {
-      return handleMcpRequest(event, mcpApiKey, mcpEnableJsonResponse, getEngine);
+      return handleMcpRequest(event, mcpAccess, mcpApiKey, mcpEnableJsonResponse, getEngine);
     }
     const targetPath = apiPath ?? config.api.path;
 
@@ -341,51 +343,6 @@ function resolveRequestedScope(
   );
 }
 
-/**
- * Strip repository paths from a page-retrieval response.
- *
- * `getPage` returns the page's indexed markdown, which is fine — it is the same
- * content the site already serves publicly. `routeFile` is not: it is a path
- * inside the author's repository, useful to an editing agent and disclosed to
- * nobody else.
- */
-function toPublicPage<T extends { frontmatter?: Record<string, unknown> }>(
-  page: T,
-  config: ResolvedSearchSocketConfig
-): T {
-  if (config.api.exposeInternalFields) return page;
-  if (!page.frontmatter) return page;
-
-  const { routeFile: _routeFile, ...frontmatter } = page.frontmatter;
-  return { ...page, frontmatter };
-}
-
-/**
- * Strip fields a public search response should not carry.
- *
- * `routeFile` is a path inside the author's repository and `chunkText` is the
- * indexed text of a matched section rather than a snippet. Both are useful to an MCP
- * client editing the site and neither belongs in a public search box, so they
- * are opt-in via `api.exposeInternalFields`.
- */
-function toPublicResults(
-  results: SearchResult[],
-  config: ResolvedSearchSocketConfig
-): SearchResult[] {
-  if (config.api.exposeInternalFields) return results;
-
-  return results.map((result) => {
-    const { routeFile: _routeFile, chunkText: _chunkText, breakdown: _breakdown, ...rest } = result;
-    return {
-      ...rest,
-      chunks: result.chunks?.map((chunk) => {
-        const { chunkText: _chunkChunkText, ...chunkRest } = chunk;
-        return chunkRest;
-      })
-    } as SearchResult;
-  });
-}
-
 function isApiPath(pathname: string, apiPath: string): boolean {
   return pathname === apiPath || pathname.startsWith(apiPath + "/");
 }
@@ -443,7 +400,7 @@ async function handleGetSearch(
   const result = await engine.search(searchRequest);
 
   return withCors(
-    new Response(JSON.stringify({ ...result, results: toPublicResults(result.results, config) }), {
+    new Response(JSON.stringify({ ...result, results: toPublicResults(result.results, !config.api.exposeInternalFields) }), {
       status: 200,
       headers: { "content-type": "application/json", "cache-control": "no-store" }
     }),
@@ -489,7 +446,7 @@ async function handleGetPage(
   const result = await engine.getPage(pagePath, scope);
 
   return withCors(
-    new Response(JSON.stringify(toPublicPage(result, config)), {
+    new Response(JSON.stringify(toPublicPage(result, !config.api.exposeInternalFields)), {
       status: 200,
       headers: { "content-type": "application/json", "cache-control": "no-store" }
     }),
@@ -571,7 +528,7 @@ async function handlePostSearch(
   const result = await engine.search(searchRequest);
 
   return withCors(
-    new Response(JSON.stringify({ ...result, results: toPublicResults(result.results, config) }), {
+    new Response(JSON.stringify({ ...result, results: toPublicResults(result.results, !config.api.exposeInternalFields) }), {
       status: 200,
       headers: { "content-type": "application/json", "cache-control": "no-store" }
     }),
@@ -582,6 +539,7 @@ async function handlePostSearch(
 
 async function handleMcpRequest(
   event: any,
+  access: "public" | "private",
   apiKey: string | undefined,
   enableJsonResponse: boolean,
   getEngine: () => Promise<SearchEngine>
@@ -620,10 +578,16 @@ async function handleMcpRequest(
 
   // MCP is a privileged surface: its tools return repository paths, a page's
   // indexed markdown, and any scope the caller names — none of which the browser API
-  // discloses. It must therefore fail closed. Previously the auth check was
-  // wrapped in `if (apiKey)`, so a deployment that never configured a key — or
-  // whose `apiKeyEnv` was unset in production — served all of that to anyone.
-  if (!apiKey) {
+  // discloses. It therefore fails closed unless the deployment says otherwise.
+  // Previously the auth check was wrapped in `if (apiKey)`, so a deployment
+  // that never configured a key — or whose `apiKeyEnv` was unset in production
+  // — served all of that to anyone.
+  //
+  // `mcp.handle.access: "public"` is the deliberate opt-out: an anonymous
+  // caller is served, but with the same fields stripped that the browser API
+  // already withholds, so what it can reach is the site's published content and
+  // nothing more.
+  if (!apiKey && access === "private") {
     return new Response(
       JSON.stringify({
         jsonrpc: "2.0",
@@ -631,7 +595,8 @@ async function handleMcpRequest(
           code: -32001,
           message:
             "MCP endpoint is not configured with an API key. Set mcp.handle.apiKey " +
-            "(or mcp.handle.apiKeyEnv) to enable it, or set mcp.enable: false to disable the route. " +
+            "(or mcp.handle.apiKeyEnv) to enable it, set mcp.handle.access: 'public' to serve " +
+            "anonymous callers a redacted result set, or set mcp.enable: false to disable the route. " +
             "If the key is set and this still fails under `vite dev`: apiKeyEnv reads process.env, " +
             "which a SvelteKit dev server does not populate from .env. Pass it explicitly instead — " +
             "mcp.handle.apiKey: env.YOUR_KEY from $env/dynamic/private."
@@ -642,12 +607,8 @@ async function handleMcpRequest(
     );
   }
 
-  const authHeader = event.request.headers.get("authorization") ?? "";
-  const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
-  const tokenBuf = Buffer.from(token);
-  const keyBuf = Buffer.from(apiKey);
-  if (tokenBuf.length !== keyBuf.length || !timingSafeEqual(tokenBuf, keyBuf)) {
-    return new Response(
+  const unauthorized = () =>
+    new Response(
       JSON.stringify({
         jsonrpc: "2.0",
         error: { code: -32001, message: "Unauthorized" },
@@ -655,6 +616,27 @@ async function handleMcpRequest(
       }),
       { status: 401, headers: { "content-type": "application/json" } }
     );
+
+  // A caller that sent no Authorization header at all is anonymous. One that
+  // sent a header is attempting to authenticate, so a wrong or malformed
+  // credential is a 401 even under public access — a misconfigured editing
+  // agent should be told its key is bad, not quietly downgraded to the public
+  // result set and left wondering where `routeFile` went.
+  const authHeader: string | null = event.request.headers.get("authorization");
+  let isAnonymous = false;
+
+  if (authHeader === null) {
+    if (access === "private") return unauthorized();
+    isAnonymous = true;
+  } else {
+    if (!apiKey) return unauthorized();
+    if (!authHeader.startsWith("Bearer ")) return unauthorized();
+
+    const token = authHeader.slice(7);
+    // `verifyApiKey` hashes both sides to equal-length digests before
+    // comparing, so an attacker cannot learn the key's length from how long a
+    // rejection takes — the previous inline length check leaked exactly that.
+    if (token.length === 0 || !verifyApiKey(token, apiKey)) return unauthorized();
   }
 
   const transport = new WebStandardStreamableHTTPServerTransport({
@@ -666,7 +648,7 @@ async function handleMcpRequest(
 
   try {
     const engine = await getEngine();
-    server = createMcpServer(engine);
+    server = createMcpServer(engine, { redact: isAnonymous });
 
     await (server as ReturnType<typeof createMcpServer>).connect(transport);
     const response = await transport.handleRequest(event.request);

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,12 @@ export interface SearchSocketConfig {
     };
     handle?: {
       path?: string;
+      /**
+       * Independent of the top-level `mcp.access`, which only governs the
+       * standalone server's bind address. "public" (default "private") serves
+       * anonymous callers a redacted result set instead of refusing them.
+       */
+      access?: "public" | "private";
       apiKey?: string;
       /** Env var holding the key, so it need not be committed. */
       apiKeyEnv?: string;
@@ -287,6 +293,7 @@ export interface ResolvedSearchSocketConfig {
     };
     handle: {
       path: string;
+      access: "public" | "private";
       apiKey?: string;
       apiKeyEnv?: string;
       enableJsonResponse: boolean;
@@ -674,7 +681,12 @@ export interface RelatedPage {
   title: string;
   score: number;
   relationshipType: RelationshipType;
-  routeFile: string;
+  /**
+   * Path to the source file in the author's repository. Omitted from results
+   * served to an anonymous MCP caller, so code reading it must handle its
+   * absence — see `SearchResult.routeFile`.
+   */
+  routeFile?: string;
 }
 
 export interface RelatedPagesResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -681,12 +681,7 @@ export interface RelatedPage {
   title: string;
   score: number;
   relationshipType: RelationshipType;
-  /**
-   * Path to the source file in the author's repository. Omitted from results
-   * served to an anonymous MCP caller, so code reading it must handle its
-   * absence — see `SearchResult.routeFile`.
-   */
-  routeFile?: string;
+  routeFile: string;
 }
 
 export interface RelatedPagesResult {

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -1,4 +1,4 @@
-import type { RelatedPagesResult, SearchResult } from "../types";
+import type { RelatedPage, RelatedPagesResult, SearchResult } from "../types";
 
 /**
  * One rule for what is privileged, applied to every surface that can serve an
@@ -62,11 +62,19 @@ export function toPublicResults(results: SearchResult[], redact: boolean): Searc
  * `get_related_pages` has no browser-API equivalent, so this leak went
  * unnoticed until MCP could serve an anonymous caller: every entry carries a
  * `routeFile`, which is the same repository path the other two surfaces hide.
+ *
+ * The engine always produces `routeFile`, so `RelatedPage` keeps it required
+ * and the stripped shape is a separate type. Widening the domain type because
+ * one serializer drops the field would break every consumer that reads it.
  */
+export interface PublicRelatedPagesResult extends Omit<RelatedPagesResult, "relatedPages"> {
+  relatedPages: Array<Omit<RelatedPage, "routeFile">>;
+}
+
 export function toPublicRelatedPages(
   result: RelatedPagesResult,
   redact: boolean
-): RelatedPagesResult {
+): RelatedPagesResult | PublicRelatedPagesResult {
   if (!redact) return result;
 
   return {

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -1,0 +1,79 @@
+import type { RelatedPagesResult, SearchResult } from "../types";
+
+/**
+ * One rule for what is privileged, applied to every surface that can serve an
+ * unauthenticated caller.
+ *
+ * The browser API has always stripped these fields unless the deployment sets
+ * `api.exposeInternalFields`. MCP used to be unconditionally key-gated, so it
+ * had no need for them — `mcp.handle.access: "public"` changes that, and both
+ * surfaces now decide with the same `redact` flag rather than each carrying its
+ * own notion of what a public caller may see.
+ *
+ * These take a plain boolean rather than the resolved config so the MCP server
+ * can reuse them without importing the SvelteKit handle (which imports it).
+ */
+
+/**
+ * Strip repository paths from a page-retrieval response.
+ *
+ * `getPage` returns the page's indexed markdown, which is fine — it is the same
+ * content the site already serves publicly. `routeFile` is not: it is a path
+ * inside the author's repository, useful to an editing agent and disclosed to
+ * nobody else.
+ */
+export function toPublicPage<T extends { frontmatter?: Record<string, unknown> }>(
+  page: T,
+  redact: boolean
+): T {
+  if (!redact) return page;
+  if (!page.frontmatter) return page;
+
+  const { routeFile: _routeFile, ...frontmatter } = page.frontmatter;
+  return { ...page, frontmatter };
+}
+
+/**
+ * Strip fields a public search response should not carry.
+ *
+ * `routeFile` is a path inside the author's repository and `chunkText` is the
+ * indexed text of a matched section rather than a snippet. Both are useful to an MCP
+ * client editing the site and neither belongs in a public search box, so they
+ * are opt-in via `api.exposeInternalFields`.
+ */
+export function toPublicResults(results: SearchResult[], redact: boolean): SearchResult[] {
+  if (!redact) return results;
+
+  return results.map((result) => {
+    const { routeFile: _routeFile, chunkText: _chunkText, breakdown: _breakdown, ...rest } = result;
+    return {
+      ...rest,
+      chunks: result.chunks?.map((chunk) => {
+        const { chunkText: _chunkChunkText, ...chunkRest } = chunk;
+        return chunkRest;
+      })
+    } as SearchResult;
+  });
+}
+
+/**
+ * Strip repository paths from a related-pages response.
+ *
+ * `get_related_pages` has no browser-API equivalent, so this leak went
+ * unnoticed until MCP could serve an anonymous caller: every entry carries a
+ * `routeFile`, which is the same repository path the other two surfaces hide.
+ */
+export function toPublicRelatedPages(
+  result: RelatedPagesResult,
+  redact: boolean
+): RelatedPagesResult {
+  if (!redact) return result;
+
+  return {
+    ...result,
+    relatedPages: result.relatedPages.map((page) => {
+      const { routeFile: _routeFile, ...rest } = page;
+      return rest;
+    })
+  };
+}

--- a/tests/api-security.test.ts
+++ b/tests/api-security.test.ts
@@ -64,6 +64,14 @@ const SAMPLE_RESPONSE: SearchResponse = {
       score: 0.9,
       routeFile: "src/routes/docs/auth/+page.svelte",
       chunkText: "The complete text of this section, verbatim.",
+      breakdown: {
+        baseScore: 0.8,
+        incomingLinkBoost: 0.05,
+        depthBoost: 0,
+        titleMatchBoost: 0.05,
+        freshnessBoost: 0,
+        anchorTextMatchBoost: 0
+      },
       chunks: [
         {
           sectionTitle: "Tokens",
@@ -175,10 +183,51 @@ describe("public versus privileged fields", () => {
 
     expect(result!.routeFile).toBeUndefined();
     expect(result!.chunkText).toBeUndefined();
+    expect(result!.breakdown).toBeUndefined();
     expect(result!.chunks![0]!.chunkText).toBeUndefined();
     // The snippet is what a search box needs, and it survives.
     expect(result!.snippet).toBe("A snippet.");
     expect(result!.url).toBe("/docs/auth");
+  });
+
+  // The POST handler redacts through a separate call site from GET. Nothing
+  // asserted on its response body, so an inverted flag there would have leaked
+  // every one of these fields with the suite still green.
+  async function postAndParse(config: ResolvedSearchSocketConfig) {
+    stubEngine();
+    const handle = searchsocketHandle({ config });
+    const resolve = vi.fn().mockResolvedValue(new Response("ok"));
+    const response = await handle({
+      event: makeEvent({
+        pathname: "/api/search",
+        method: "POST",
+        body: { q: "test" },
+        headers: { "content-type": "application/json" }
+      }),
+      resolve
+    });
+    return (await response.json()) as SearchResponse;
+  }
+
+  it("omits the same fields from a POST search", async () => {
+    const body = await postAndParse(makeConfig());
+    const [result] = body.results;
+
+    expect(result!.routeFile).toBeUndefined();
+    expect(result!.chunkText).toBeUndefined();
+    expect(result!.breakdown).toBeUndefined();
+    expect(result!.chunks![0]!.chunkText).toBeUndefined();
+    expect(result!.snippet).toBe("A snippet.");
+  });
+
+  it("includes them on a POST search when the deployment opts in", async () => {
+    const body = await postAndParse(
+      makeConfig({ api: { exposeInternalFields: true } } as Partial<ResolvedSearchSocketConfig>)
+    );
+    const [result] = body.results;
+
+    expect(result!.routeFile).toBe("src/routes/docs/auth/+page.svelte");
+    expect(result!.chunkText).toContain("verbatim");
   });
 
   it("includes them when the deployment opts in", async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -375,6 +375,70 @@ describe("mergeConfig mcp.access", () => {
   });
 });
 
+describe("mergeConfig mcp.handle.access", () => {
+  it("defaults to private so existing deployments keep failing closed", async () => {
+    const dir = await makeTempDir();
+    await fs.mkdir(path.join(dir, "build"), { recursive: true });
+
+    const merged = mergeConfig(dir, {});
+    expect(merged.mcp.handle.access).toBe("private");
+  });
+
+  it("does not require a key when public — that is the point of the setting", async () => {
+    const dir = await makeTempDir();
+    await fs.mkdir(path.join(dir, "build"), { recursive: true });
+
+    const merged = mergeConfig(dir, {
+      mcp: { handle: { access: "public" } }
+    });
+
+    expect(merged.mcp.handle.access).toBe("public");
+    expect(merged.mcp.handle.apiKey).toBeUndefined();
+  });
+
+  it("keeps the private default when another handle field is supplied", async () => {
+    const dir = await makeTempDir();
+    await fs.mkdir(path.join(dir, "build"), { recursive: true });
+
+    const merged = mergeConfig(dir, {
+      mcp: { handle: { path: "/mcp" } }
+    });
+
+    expect(merged.mcp.handle.path).toBe("/mcp");
+    expect(merged.mcp.handle.access).toBe("private");
+  });
+
+  it("rejects a value outside the enum", async () => {
+    const dir = await makeTempDir();
+    await fs.mkdir(path.join(dir, "build"), { recursive: true });
+
+    expect(() =>
+      mergeConfig(dir, {
+        mcp: { handle: { access: "open" } }
+      } as never)
+    ).toThrow();
+  });
+
+  it("is independent of the standalone mcp.access guard", async () => {
+    const dir = await makeTempDir();
+    await fs.mkdir(path.join(dir, "build"), { recursive: true });
+
+    // A public handle route must not satisfy the standalone server's key
+    // requirement, and must not be dragged into failing by it either.
+    expect(() =>
+      mergeConfig(dir, {
+        mcp: { access: "public", handle: { access: "public" } }
+      })
+    ).toThrow("mcp.http.apiKey");
+
+    const merged = mergeConfig(dir, {
+      mcp: { handle: { access: "public" } }
+    });
+    expect(merged.mcp.access).toBe("private");
+    expect(merged.mcp.handle.access).toBe("public");
+  });
+});
+
 describe("mergeConfig legacy analytics field", () => {
   it("silently strips removed analytics field from user config", async () => {
     const dir = await makeTempDir();

--- a/tests/handle.test.ts
+++ b/tests/handle.test.ts
@@ -1641,6 +1641,52 @@ describe("MCP endpoint", () => {
       expect(mockedCreateServer).not.toHaveBeenCalled();
     });
 
+    it("does not let the size check pre-empt the auth contract", async () => {
+      // An oversized body must not turn a private deployment's 503 into a 413,
+      // which would also tell an unauthenticated caller the configured limit.
+      const privateNoKey = makeConfig();
+      const withKey = makeConfig();
+      withKey.mcp.handle.apiKey = "test-secret";
+      vi.spyOn(SearchEngine, "create").mockResolvedValue({
+        search: vi.fn()
+      } as unknown as SearchEngine);
+
+      const oversized = () =>
+        makeEvent({
+          pathname: "/api/mcp",
+          method: "POST",
+          body: { jsonrpc: "2.0", method: "initialize", id: 1 },
+          contentLength: 5000
+        });
+      const resolve = vi.fn().mockResolvedValue(new Response("ok"));
+
+      const noKey = await searchsocketHandle({ config: privateNoKey, maxBodyBytes: 128 })({
+        event: oversized(),
+        resolve
+      });
+      expect(noKey.status).toBe(503);
+
+      const noToken = await searchsocketHandle({ config: withKey, maxBodyBytes: 128 })({
+        event: oversized(),
+        resolve
+      });
+      expect(noToken.status).toBe(401);
+    });
+
+    it("accepts extra spaces after the bearer scheme", async () => {
+      // RFC 7235 grammar is `1*SP` between scheme and credential.
+      const handle = searchsocketHandle({ config: publicConfig("test-secret") });
+      const resolve = vi.fn().mockResolvedValue(new Response("ok"));
+
+      const response = await handle({
+        event: mcpEvent({ authorization: "Bearer   test-secret" }),
+        resolve
+      });
+
+      expect(response.status).toBe(200);
+      expect(redactFlag()).toBe(false);
+    });
+
     it("reaches the same policy through the deferred routing branch", async () => {
       // Three call sites forward `mcpAccess`; the inline-config tests above only
       // exercise one. Warming the config with a non-MCP request first routes the

--- a/tests/handle.test.ts
+++ b/tests/handle.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { searchsocketHandle } from "../src/sveltekit/handle";
+import { createServer as mockedCreateServer } from "../src/mcp/server";
 import { createDefaultConfig } from "../src/config/defaults";
 import { SearchEngine } from "../src/search/engine";
 import { SearchSocketError } from "../src/errors";
@@ -1433,7 +1434,7 @@ describe("MCP endpoint", () => {
     expect(response.status).toBe(200);
   });
 
-  it("refuses to serve MCP at all when no API key is configured", async () => {
+  it("refuses to serve MCP at all when no API key is configured and access is private", async () => {
     // MCP returns repository paths, full page markdown, and any scope the
     // caller names. The auth check used to be wrapped in `if (apiKey)`, so a
     // deployment that never configured one served all of that to anyone.
@@ -1457,6 +1458,133 @@ describe("MCP endpoint", () => {
     const response = await handle({ event, resolve });
     expect(response.status).toBe(503);
     expect(search).not.toHaveBeenCalled();
+  });
+
+  describe("mcp.handle.access: \"public\"", () => {
+    /** The mock is module-level, so a stale call would leak between assertions. */
+    beforeEach(() => {
+      (mockedCreateServer as unknown as ReturnType<typeof vi.fn>).mockClear();
+    });
+
+    function redactFlag(): boolean | undefined {
+      const calls = (mockedCreateServer as unknown as ReturnType<typeof vi.fn>).mock.calls;
+      const last = calls[calls.length - 1];
+      return (last?.[1] as { redact?: boolean } | undefined)?.redact;
+    }
+
+    function publicConfig(apiKey?: string) {
+      const config = makeConfig();
+      config.mcp.handle.access = "public";
+      if (apiKey) config.mcp.handle.apiKey = apiKey;
+      vi.spyOn(SearchEngine, "create").mockResolvedValue({
+        search: vi.fn()
+      } as unknown as SearchEngine);
+      return config;
+    }
+
+    function mcpEvent(headers?: Record<string, string>) {
+      return makeEvent({
+        pathname: "/api/mcp",
+        method: "POST",
+        body: { jsonrpc: "2.0", method: "initialize", id: 1 },
+        ...(headers ? { headers } : {})
+      });
+    }
+
+    it("serves an anonymous caller a redacted server when no key is configured", async () => {
+      // The point of the setting: a site can publish its MCP endpoint without
+      // publishing a bearer token, which would hand out the very fields the
+      // 503 existed to protect.
+      const handle = searchsocketHandle({ config: publicConfig() });
+      const resolve = vi.fn().mockResolvedValue(new Response("ok"));
+
+      const response = await handle({ event: mcpEvent(), resolve });
+
+      expect(response.status).toBe(200);
+      expect(redactFlag()).toBe(true);
+    });
+
+    it("serves an anonymous caller a redacted server even when a key is configured", async () => {
+      const handle = searchsocketHandle({ config: publicConfig("test-secret") });
+      const resolve = vi.fn().mockResolvedValue(new Response("ok"));
+
+      const response = await handle({ event: mcpEvent(), resolve });
+
+      expect(response.status).toBe(200);
+      expect(redactFlag()).toBe(true);
+    });
+
+    it("gives a valid bearer token the unredacted server", async () => {
+      const handle = searchsocketHandle({ config: publicConfig("test-secret") });
+      const resolve = vi.fn().mockResolvedValue(new Response("ok"));
+
+      const response = await handle({
+        event: mcpEvent({ authorization: "Bearer test-secret" }),
+        resolve
+      });
+
+      expect(response.status).toBe(200);
+      expect(redactFlag()).toBe(false);
+    });
+
+    it("401s a wrong token rather than downgrading it to anonymous", async () => {
+      // A bad key is a misconfigured client, not a member of the public. Silently
+      // serving it the redacted set would leave it wondering where routeFile went.
+      const handle = searchsocketHandle({ config: publicConfig("test-secret") });
+      const resolve = vi.fn().mockResolvedValue(new Response("ok"));
+
+      const response = await handle({
+        event: mcpEvent({ authorization: "Bearer wrong-key" }),
+        resolve
+      });
+
+      expect(response.status).toBe(401);
+      expect(mockedCreateServer).not.toHaveBeenCalled();
+    });
+
+    it("401s a malformed Authorization header", async () => {
+      const handle = searchsocketHandle({ config: publicConfig("test-secret") });
+      const resolve = vi.fn().mockResolvedValue(new Response("ok"));
+
+      for (const authorization of ["test-secret", "Basic test-secret", "Bearer ", ""]) {
+        const response = await handle({ event: mcpEvent({ authorization }), resolve });
+        expect(response.status).toBe(401);
+      }
+      expect(mockedCreateServer).not.toHaveBeenCalled();
+    });
+
+    it("401s a presented token when no key is configured to validate it against", async () => {
+      const handle = searchsocketHandle({ config: publicConfig() });
+      const resolve = vi.fn().mockResolvedValue(new Response("ok"));
+
+      const response = await handle({
+        event: mcpEvent({ authorization: "Bearer anything" }),
+        resolve
+      });
+
+      expect(response.status).toBe(401);
+      expect(mockedCreateServer).not.toHaveBeenCalled();
+    });
+
+    it("leaves the private default building an unredacted server", async () => {
+      const config = makeConfig();
+      config.mcp.handle.apiKey = "test-secret";
+      expect(config.mcp.handle.access).toBe("private");
+      vi.spyOn(SearchEngine, "create").mockResolvedValue({
+        search: vi.fn()
+      } as unknown as SearchEngine);
+
+      const handle = searchsocketHandle({ config });
+      const resolve = vi.fn().mockResolvedValue(new Response("ok"));
+
+      const response = await handle({
+        event: mcpEvent({ authorization: "Bearer test-secret" }),
+        resolve
+      });
+
+      expect(response.status).toBe(200);
+      expect(redactFlag()).toBe(false);
+    });
   });
 
   it("reads the API key from apiKeyEnv so it need not be committed", async () => {

--- a/tests/handle.test.ts
+++ b/tests/handle.test.ts
@@ -1566,6 +1566,97 @@ describe("MCP endpoint", () => {
       expect(mockedCreateServer).not.toHaveBeenCalled();
     });
 
+    it("treats a config object without the field as private, not public", async () => {
+      // `searchsocketHandle({ config })` hands the object straight through with
+      // no schema parse or default merge, so a config built before this field
+      // existed arrives with `access` undefined. Reading that as anything but
+      // private would silently open every such deployment.
+      const config = makeConfig();
+      delete (config.mcp.handle as { access?: string }).access;
+      vi.spyOn(SearchEngine, "create").mockResolvedValue({
+        search: vi.fn()
+      } as unknown as SearchEngine);
+
+      const handle = searchsocketHandle({ config });
+      const resolve = vi.fn().mockResolvedValue(new Response("ok"));
+
+      const response = await handle({ event: mcpEvent(), resolve });
+
+      expect(response.status).toBe(503);
+      expect(mockedCreateServer).not.toHaveBeenCalled();
+    });
+
+    it("treats an unrecognised access value as private", async () => {
+      const config = makeConfig();
+      (config.mcp.handle as { access: string }).access = "open";
+      config.mcp.handle.apiKey = "test-secret";
+      vi.spyOn(SearchEngine, "create").mockResolvedValue({
+        search: vi.fn()
+      } as unknown as SearchEngine);
+
+      const handle = searchsocketHandle({ config });
+      const resolve = vi.fn().mockResolvedValue(new Response("ok"));
+
+      const response = await handle({ event: mcpEvent(), resolve });
+
+      expect(response.status).toBe(401);
+      expect(mockedCreateServer).not.toHaveBeenCalled();
+    });
+
+    it("accepts a lowercase bearer scheme", async () => {
+      // RFC 7235 §2.1: scheme names are case-insensitive.
+      const handle = searchsocketHandle({ config: publicConfig("test-secret") });
+      const resolve = vi.fn().mockResolvedValue(new Response("ok"));
+
+      const response = await handle({
+        event: mcpEvent({ authorization: "bearer test-secret" }),
+        resolve
+      });
+
+      expect(response.status).toBe(200);
+      expect(redactFlag()).toBe(false);
+    });
+
+    it("rejects a body larger than maxBodyBytes before reaching the engine", async () => {
+      const create = vi.spyOn(SearchEngine, "create").mockResolvedValue({
+        search: vi.fn()
+      } as unknown as SearchEngine);
+
+      const config = makeConfig();
+      config.mcp.handle.access = "public";
+      const handle = searchsocketHandle({ config, maxBodyBytes: 128 });
+      const resolve = vi.fn().mockResolvedValue(new Response("ok"));
+
+      const event = makeEvent({
+        pathname: "/api/mcp",
+        method: "POST",
+        body: { jsonrpc: "2.0", method: "initialize", id: 1 },
+        contentLength: 5000
+      });
+
+      const response = await handle({ event, resolve });
+
+      expect(response.status).toBe(413);
+      expect(create).not.toHaveBeenCalled();
+      expect(mockedCreateServer).not.toHaveBeenCalled();
+    });
+
+    it("reaches the same policy through the deferred routing branch", async () => {
+      // Three call sites forward `mcpAccess`; the inline-config tests above only
+      // exercise one. Warming the config with a non-MCP request first routes the
+      // MCP request through a different branch.
+      const config = publicConfig();
+      const handle = searchsocketHandle({ config, path: "/api/search" });
+      const resolve = vi.fn().mockResolvedValue(new Response("ok"));
+
+      await handle({ event: makeEvent({ pathname: "/other", method: "GET" }), resolve });
+      const response = await handle({ event: mcpEvent(), resolve });
+
+      expect(response.status).toBe(200);
+      expect(mockedCreateServer).toHaveBeenCalledTimes(1);
+      expect(redactFlag()).toBe(true);
+    });
+
     it("leaves the private default building an unredacted server", async () => {
       const config = makeConfig();
       config.mcp.handle.apiKey = "test-secret";

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -523,6 +523,31 @@ describe("redacted servers (mcp.handle.access: \"public\")", () => {
               chunkText: "Tokens expire after an hour.",
               headingPath: ["Auth", "Tokens"],
               score: 0.7
+            },
+            {
+              sectionTitle: "Refresh",
+              snippet: "Refresh tokens rotate.",
+              chunkText: "Refresh tokens rotate on every use.",
+              headingPath: ["Auth", "Refresh"],
+              score: 0.6
+            }
+          ]
+        },
+        {
+          url: "/docs/api",
+          title: "API",
+          snippet: "The HTTP API.",
+          score: 0.5,
+          chunkText: "Second result indexed text.",
+          routeFile: "src/routes/docs/api/+page.svelte",
+          breakdown: { baseScore: 0.4, incomingLinkBoost: 0.05 },
+          chunks: [
+            {
+              sectionTitle: "Endpoints",
+              snippet: "Endpoints listed.",
+              chunkText: "Every endpoint, listed.",
+              headingPath: ["API", "Endpoints"],
+              score: 0.4
             }
           ]
         }
@@ -538,13 +563,18 @@ describe("redacted servers (mcp.handle.access: \"public\")", () => {
     const handler = getHandler(mockEngine, "search", true);
     const parsed = JSON.parse((await handler({ query: "auth" })).content[0]!.text);
 
-    const [result] = parsed.results;
-    expect(result.routeFile).toBeUndefined();
-    expect(result.chunkText).toBeUndefined();
-    expect(result.breakdown).toBeUndefined();
-    expect(result.chunks[0].chunkText).toBeUndefined();
+    expect(parsed.results).toHaveLength(2);
+    for (const result of parsed.results) {
+      expect(result.routeFile).toBeUndefined();
+      expect(result.chunkText).toBeUndefined();
+      expect(result.breakdown).toBeUndefined();
+      for (const chunk of result.chunks) {
+        expect(chunk.chunkText).toBeUndefined();
+      }
+    }
 
     // Everything the site already publishes survives.
+    const [result] = parsed.results;
     expect(result.url).toBe("/docs/auth");
     expect(result.title).toBe("Auth");
     expect(result.snippet).toBe("How to authenticate.");
@@ -556,12 +586,17 @@ describe("redacted servers (mcp.handle.access: \"public\")", () => {
 
   it("does not mutate the engine result while redacting", async () => {
     const response = searchResponse();
+    const pristine = structuredClone(response);
     const mockEngine = { search: vi.fn().mockResolvedValue(response) };
 
-    await getHandler(mockEngine, "search", true)({ query: "auth" });
+    const parsed = JSON.parse(
+      (await getHandler(mockEngine, "search", true)({ query: "auth" })).content[0]!.text
+    );
 
-    expect(response.results[0]!.routeFile).toBe("src/routes/docs/auth/+page.svelte");
-    expect(response.results[0]!.chunks[0]!.chunkText).toBe("Tokens expire after an hour.");
+    // The returned payload really was redacted...
+    expect(parsed.results[0].routeFile).toBeUndefined();
+    // ...and the engine's own object came through untouched.
+    expect(response).toEqual(pristine);
   });
 
   it("strips frontmatter.routeFile from get_page but keeps the markdown", async () => {
@@ -625,6 +660,51 @@ describe("redacted servers (mcp.handle.access: \"public\")", () => {
     expect(mockEngine.getRelatedPages).toHaveBeenCalledWith("/a", { topK: undefined, scope: undefined });
   });
 
+  it("forces the scope on the get_page not-found suggestion search too", async () => {
+    // The fallback issues a *second* engine call, and it was the one most
+    // likely to be missed — it would hand back staging URLs as "similar pages".
+    const mockEngine = {
+      search: vi.fn().mockResolvedValue({ q: "/docs/missing", scope: "main", results: [], meta: {} }),
+      getPage: vi.fn().mockRejectedValue(notFoundError())
+    };
+
+    const handler = getHandler(mockEngine, "get_page", true);
+    await handler({ path: "/docs/missing", scope: "staging" });
+
+    expect(mockEngine.getPage).toHaveBeenCalledWith("/docs/missing", undefined);
+    expect(mockEngine.search).toHaveBeenCalledWith({
+      q: "/docs/missing",
+      topK: 3,
+      scope: undefined
+    });
+  });
+
+  it("reports an engine failure to an anonymous caller without naming internals", async () => {
+    // SDK 1.26 turns a thrown error into an isError result carrying the message
+    // verbatim, and engine messages name env vars and backend URLs.
+    const leaky = new Error("Scope mode is env but PRIVATE_PREVIEW_SCOPE is not set.");
+    const mockEngine = {
+      search: vi.fn().mockRejectedValue(leaky),
+      getRelatedPages: vi.fn().mockRejectedValue(leaky)
+    };
+
+    for (const tool of ["search", "get_related_pages"]) {
+      const handler = getHandler(mockEngine, tool, true);
+      const result = await handler(tool === "search" ? { query: "x" } : { path: "/a" });
+      const text = result.content[0]!.text;
+      expect(text).not.toContain("PRIVATE_PREVIEW_SCOPE");
+      expect(text).toContain("INTERNAL_ERROR");
+    }
+  });
+
+  it("still propagates the real error to a privileged caller", async () => {
+    const mockEngine = { search: vi.fn().mockRejectedValue(new Error("Upstash unreachable")) };
+
+    await expect(getHandler(mockEngine, "search", false)({ query: "x" })).rejects.toThrow(
+      "Upstash unreachable"
+    );
+  });
+
   it("still forwards a scope for a privileged caller", async () => {
     const mockEngine = {
       search: vi.fn().mockResolvedValue({ q: "x", scope: "staging", results: [], meta: {} })
@@ -642,6 +722,8 @@ describe("redacted servers (mcp.handle.access: \"public\")", () => {
     const parsed = JSON.parse((await handler({ query: "auth" })).content[0]!.text);
 
     expect(parsed).toEqual(response);
+    expect(parsed.results[0].routeFile).toBe("src/routes/docs/auth/+page.svelte");
+    expect(parsed.results[1].chunks[0].chunkText).toBe("Every endpoint, listed.");
   });
 
   it("keeps the standalone default unredacted when no options are passed", async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -485,6 +485,199 @@ describe("get_related_pages tool", () => {
   });
 });
 
+describe("redacted servers (mcp.handle.access: \"public\")", () => {
+  function getHandler(mockEngine: Record<string, unknown>, name: string, redact: boolean) {
+    const server = createServer(mockEngine as never, { redact });
+    const calls = (server.registerTool as ReturnType<typeof vi.fn>).mock.calls;
+    const call = calls.find((c: unknown[]) => c[0] === name);
+    expect(call).toBeDefined();
+    return call![2] as (input: Record<string, unknown>) => Promise<{
+      content: Array<{ type: string; text: string }>;
+    }>;
+  }
+
+  function getToolConfig(mockEngine: Record<string, unknown>, name: string, redact: boolean) {
+    const server = createServer(mockEngine as never, { redact });
+    const calls = (server.registerTool as ReturnType<typeof vi.fn>).mock.calls;
+    const call = calls.find((c: unknown[]) => c[0] === name);
+    return call![1] as { description: string };
+  }
+
+  function searchResponse() {
+    return {
+      q: "auth",
+      scope: "main",
+      results: [
+        {
+          url: "/docs/auth",
+          title: "Auth",
+          snippet: "How to authenticate.",
+          score: 0.9,
+          chunkText: "The full indexed section text.",
+          routeFile: "src/routes/docs/auth/+page.svelte",
+          breakdown: { baseScore: 0.8, incomingLinkBoost: 0.1 },
+          chunks: [
+            {
+              sectionTitle: "Tokens",
+              snippet: "Tokens expire.",
+              chunkText: "Tokens expire after an hour.",
+              headingPath: ["Auth", "Tokens"],
+              score: 0.7
+            }
+          ]
+        }
+      ],
+      meta: { timingsMs: { search: 1, total: 2 } }
+    };
+  }
+
+  it("strips routeFile, chunkText and breakdown from search results", async () => {
+    const response = searchResponse();
+    const mockEngine = { search: vi.fn().mockResolvedValue(response) };
+
+    const handler = getHandler(mockEngine, "search", true);
+    const parsed = JSON.parse((await handler({ query: "auth" })).content[0]!.text);
+
+    const [result] = parsed.results;
+    expect(result.routeFile).toBeUndefined();
+    expect(result.chunkText).toBeUndefined();
+    expect(result.breakdown).toBeUndefined();
+    expect(result.chunks[0].chunkText).toBeUndefined();
+
+    // Everything the site already publishes survives.
+    expect(result.url).toBe("/docs/auth");
+    expect(result.title).toBe("Auth");
+    expect(result.snippet).toBe("How to authenticate.");
+    expect(result.score).toBe(0.9);
+    expect(result.chunks[0].snippet).toBe("Tokens expire.");
+    expect(parsed.q).toBe("auth");
+    expect(parsed.meta).toEqual({ timingsMs: { search: 1, total: 2 } });
+  });
+
+  it("does not mutate the engine result while redacting", async () => {
+    const response = searchResponse();
+    const mockEngine = { search: vi.fn().mockResolvedValue(response) };
+
+    await getHandler(mockEngine, "search", true)({ query: "auth" });
+
+    expect(response.results[0]!.routeFile).toBe("src/routes/docs/auth/+page.svelte");
+    expect(response.results[0]!.chunks[0]!.chunkText).toBe("Tokens expire after an hour.");
+  });
+
+  it("strips frontmatter.routeFile from get_page but keeps the markdown", async () => {
+    const mockEngine = {
+      search: vi.fn(),
+      getPage: vi.fn().mockResolvedValue({
+        url: "/docs/auth",
+        frontmatter: { title: "Auth", tags: ["a"], routeFile: "src/routes/docs/auth/+page.svelte" },
+        markdown: "# Auth\n\nContent here."
+      })
+    };
+
+    const handler = getHandler(mockEngine, "get_page", true);
+    const parsed = JSON.parse((await handler({ path: "/docs/auth" })).content[0]!.text);
+
+    expect(parsed.frontmatter.routeFile).toBeUndefined();
+    expect(parsed.frontmatter.title).toBe("Auth");
+    expect(parsed.frontmatter.tags).toEqual(["a"]);
+    // The markdown is the same content the site serves publicly, so it stays.
+    expect(parsed.markdown).toBe("# Auth\n\nContent here.");
+  });
+
+  it("strips routeFile from every related page", async () => {
+    const mockEngine = {
+      search: vi.fn(),
+      getRelatedPages: vi.fn().mockResolvedValue({
+        sourceUrl: "/docs/auth",
+        scope: "main",
+        relatedPages: [
+          { url: "/docs/api", title: "API", score: 0.87, relationshipType: "outgoing_link", routeFile: "src/routes/docs/api/+page.svelte" },
+          { url: "/docs/security", title: "Security", score: 0.73, relationshipType: "semantic", routeFile: "src/routes/docs/security/+page.svelte" }
+        ]
+      })
+    };
+
+    const handler = getHandler(mockEngine, "get_related_pages", true);
+    const parsed = JSON.parse((await handler({ path: "/docs/auth" })).content[0]!.text);
+
+    expect(parsed.relatedPages).toHaveLength(2);
+    for (const page of parsed.relatedPages) {
+      expect(page.routeFile).toBeUndefined();
+    }
+    expect(parsed.relatedPages[0].url).toBe("/docs/api");
+    expect(parsed.relatedPages[0].relationshipType).toBe("outgoing_link");
+  });
+
+  it("ignores a caller-supplied scope so anonymous callers cannot read a staging namespace", async () => {
+    const mockEngine = {
+      search: vi.fn().mockResolvedValue({ q: "x", scope: "main", results: [], meta: {} }),
+      getPage: vi.fn().mockResolvedValue({ url: "/a", frontmatter: {}, markdown: "" }),
+      getRelatedPages: vi.fn().mockResolvedValue({ sourceUrl: "/a", scope: "main", relatedPages: [] })
+    };
+
+    await getHandler(mockEngine, "search", true)({ query: "x", scope: "staging" });
+    expect(mockEngine.search).toHaveBeenCalledWith(expect.objectContaining({ scope: undefined }));
+
+    await getHandler(mockEngine, "get_page", true)({ path: "/a", scope: "staging" });
+    expect(mockEngine.getPage).toHaveBeenCalledWith("/a", undefined);
+
+    await getHandler(mockEngine, "get_related_pages", true)({ path: "/a", scope: "staging" });
+    expect(mockEngine.getRelatedPages).toHaveBeenCalledWith("/a", { topK: undefined, scope: undefined });
+  });
+
+  it("still forwards a scope for a privileged caller", async () => {
+    const mockEngine = {
+      search: vi.fn().mockResolvedValue({ q: "x", scope: "staging", results: [], meta: {} })
+    };
+
+    await getHandler(mockEngine, "search", false)({ query: "x", scope: "staging" });
+    expect(mockEngine.search).toHaveBeenCalledWith(expect.objectContaining({ scope: "staging" }));
+  });
+
+  it("leaves results untouched when redact is not set", async () => {
+    const response = searchResponse();
+    const mockEngine = { search: vi.fn().mockResolvedValue(response) };
+
+    const handler = getHandler(mockEngine, "search", false);
+    const parsed = JSON.parse((await handler({ query: "auth" })).content[0]!.text);
+
+    expect(parsed).toEqual(response);
+  });
+
+  it("keeps the standalone default unredacted when no options are passed", async () => {
+    const response = searchResponse();
+    const mockEngine = { search: vi.fn().mockResolvedValue(response) };
+    const server = createServer(mockEngine as never);
+    const calls = (server.registerTool as ReturnType<typeof vi.fn>).mock.calls;
+    const handler = calls.find((c: unknown[]) => c[0] === "search")![2] as (
+      input: Record<string, unknown>
+    ) => Promise<{ content: Array<{ type: string; text: string }> }>;
+
+    const parsed = JSON.parse((await handler({ query: "auth" })).content[0]!.text);
+    expect(parsed.results[0].routeFile).toBe("src/routes/docs/auth/+page.svelte");
+  });
+
+  it("does not advertise fields a redacted caller will never receive", () => {
+    const mockEngine = { search: vi.fn(), getPage: vi.fn() };
+
+    const publicSearch = getToolConfig(mockEngine, "search", true).description;
+    expect(publicSearch).not.toContain("routeFile");
+    expect(publicSearch).not.toContain("chunkText");
+
+    const publicGetPage = getToolConfig(mockEngine, "get_page", true).description;
+    expect(publicGetPage).not.toContain("routeFile");
+    // The caveats about what the markdown is still apply.
+    expect(publicGetPage).toContain("NOT byte-exact source");
+  });
+
+  it("keeps the editing-oriented descriptions for a privileged caller", () => {
+    const mockEngine = { search: vi.fn(), getPage: vi.fn() };
+
+    expect(getToolConfig(mockEngine, "search", false).description).toContain("routeFile");
+    expect(getToolConfig(mockEngine, "get_page", false).description).toContain("routeFile");
+  });
+});
+
 describe("verifyApiKey", () => {
   it("returns true for matching keys", () => {
     expect(verifyApiKey("test-key-123", "test-key-123")).toBe(true);


### PR DESCRIPTION
Adds `mcp.handle.access` (`public` | `private`, default `private`) so a site can publish its MCP endpoint without publishing a bearer token. Default is unchanged, so existing deployments see no difference.

With `access: "public"`:
- a caller presenting no `Authorization` header is served instead of getting the 503
- `routeFile`, `chunkText` and `breakdown` are stripped from every tool result, and `chunkText` from nested chunks — the same fields `api.exposeInternalFields` already withholds from the browser API
- a valid bearer token still returns them, so an editing agent configured with the key keeps source paths and a public agent does not
- a wrong or malformed token is a 401, not a silent downgrade to the public result set — a misconfigured client should be told its key is bad

Full matrix:

| access | key configured | Authorization | result |
|---|---|---|---|
| private | no | any | 503 (unchanged) |
| private | yes | absent / malformed / wrong | 401 (unchanged) |
| private | yes | valid | 200 unredacted (unchanged) |
| public | no | absent | 200 redacted |
| public | no | present | 401 — no key exists to validate against |
| public | yes | absent | 200 redacted |
| public | yes | malformed / wrong | 401 |
| public | yes | valid | 200 unredacted |

### Beyond the issue

Three things the issue did not ask for but that the anonymous path made load-bearing:

**Scope.** `resolveScope(config, override)` takes any override it is given. The browser endpoint gates that through `api.allowedScopes`, but MCP never did — so an anonymous caller could have named a guessed `staging` or a branch name and read content the site has not published, which no amount of field redaction covers. Anonymous callers now get the deployment's default scope, on all four engine calls including the `get_page` not-found suggestion search. Privileged callers are unaffected.

**`get_related_pages`.** It has no browser-API equivalent, so its `routeFile` had never been considered. It is the same repository path the other two tools hide, and it is redacted now too.

**Error messages.** The SDK turns a thrown tool error into an `isError` result carrying `error.message` verbatim, and engine messages name internals — an unset scope env var reports the variable's name. Anonymous callers now get a typed code; privileged callers still get the real error, which their clients rely on.

### Notes

- `toPublicPage` / `toPublicResults` moved out of `handle.ts` into `src/utils/redact.ts` and take a plain boolean instead of the config, so the browser API and MCP decide with one rule rather than each carrying its own. `handle.ts` importing them back from `mcp/server.ts` would have been circular.
- `handleMcpRequest` now uses `verifyApiKey` instead of an inline `timingSafeEqual`; the old code short-circuited on a length mismatch, which leaked the key's length through timing.
- The route now bounds the declared `content-length`. The transport owns the body stream so this is the header only — but until now every caller here had presented a key.
- `RelatedPage.routeFile` stays required; the stripped form is a separate `PublicRelatedPagesResult`.
- Docs: corrected the three lines in `docs/config.md` that said the key was required for the endpoint to serve anything.

### Known follow-ups (not in this PR)

- The MCP route returns before the rate limiter, so anonymous calls are not rate limited. Pre-existing, and the in-memory limiter is disabled on serverless by design — this needs its own issue.
- MCP responses bypass `withCors` and `OPTIONS` is not handled as a preflight, so a public endpoint is not browser-callable cross-origin. Also pre-existing.

### Testing

377 tests across 14 files pass, typecheck clean. New coverage: the full auth matrix, redaction of all three tools, the fail-open case where an inline config object predates the field, scope forcing including the not-found fallback, the error boundary, and the REST POST redaction call site — which had no assertion on its response body, so an inverted flag there would have leaked every field with the suite green.

Resolves #80